### PR TITLE
Fix default data and use latest lib and platform versions

### DIFF
--- a/data/tracker_config.json
+++ b/data/tracker_config.json
@@ -1,7 +1,7 @@
 {
 	"beacons": [
 		{
-			"callsign": "CD2RXU-7",
+			"callsign": "NOCALL-7",
 			"symbol": "[",
 			"comment": "github.com/richonguzman/LoRa_APRS_Tracker",
 			"smart_beacon": {
@@ -20,7 +20,7 @@
 			"overlay": "/"
 		},
 		{
-			"callsign": "CD2RXU-8",
+			"callsign": "NOCALL-8",
 			"symbol": "b",
 			"comment": "github.com/richonguzman/LoRa_APRS_Tracker",	
 			"smart_beacon": {
@@ -40,7 +40,7 @@
 
 		},
 		{
-			"callsign": "CD2RXU-9",
+			"callsign": "NOCALL-9",
 			"symbol": ">",
 			"comment": "github.com/richonguzman/LoRa_APRS_Tracker",
 			"smart_beacon": {

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,12 +2,13 @@
 default_envs = ttgo-t-beam-v1
 
 [env]
-platform = espressif32 @ 6.2.0
+platform = espressif32 @ 6.3.1
 framework = arduino
 lib_ldf_mode = deep+
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 lib_deps = 
+	adafruit/Adafruit BusIO@^1.14.1
 	adafruit/Adafruit GFX Library @ 1.11.5
 	adafruit/Adafruit SSD1306 @ 2.5.7
 	bblanchon/ArduinoJson @ 6.21.2
@@ -15,7 +16,7 @@ lib_deps =
 	sandeepmistry/LoRa @ 0.8.0
 	peterus/APRS-Decoder-Lib @ 0.0.6
 	mikalhart/TinyGPSPlus @ 1.0.3
-	paulstoffregen/Time @ 1.6
+	paulstoffregen/Time @ 1.6.1
 	shaggydog/OneButton @ 1.5.0
 	peterus/esp-logger @ 1.0.0
 check_tool = cppcheck

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -1019,7 +1019,7 @@ void loop() {
 
 /// FUNCTIONS ///
 void validateConfigFile() {
-  if (currentBeacon->callsign == "NOCALL-10") {
+  if (currentBeacon->callsign == "NOCALL-7") {
     logger.log(logging::LoggerLevel::LOGGER_LEVEL_ERROR, "Config",
                "You have to change your settings in 'data/tracker.json' and "
                "upload it via \"Upload File System image\"!");


### PR DESCRIPTION
- Fixes for default USER ID to be by default NOCALL based, and the default USER-ID is NOCALL-7 to avoid a collision with "-10" which is more reserved for an igate, and also adjust the unconfigured USER ID error check to NOCALL-7
- Update the used espressif32 platform from 6.2.0 to the latest version 6.3.1
- Use the latest Time library version 1.6.1
- Add explicitly an implicitly dependency downloaded Adafruit BusIO library, i.e. make all used libraries directly visible in the libs_dep section
