### PR TITLE
Small main menu refactor

### DIFF
--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -212,21 +212,24 @@ namespace LoRa_Utils {
             transmissionFlag = false;
             radio.startReceive();
             int state = radio.readData(packet);
-            if (state == RADIOLIB_ERR_NONE) {
-                if(!packet.isEmpty()) {
-                    logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa Rx","---> %s", packet.c_str());
-                }
-                receivedLoraPacket.text       = packet;
-                receivedLoraPacket.rssi       = radio.getRSSI();
-                receivedLoraPacket.snr        = radio.getSNR();
-                receivedLoraPacket.freqError  = radio.getFrequencyError();
-            } else if (state == RADIOLIB_ERR_RX_TIMEOUT) {
-                // timeout occurred while waiting for a packet
-            } else if (state == RADIOLIB_ERR_CRC_MISMATCH) {
-                Serial.println(F("CRC error!"));
-            } else {
-                Serial.print(F("failed, code "));
-                Serial.println(state);
+            switch (state) {
+                case RADIOLIB_ERR_NONE:
+                    if(!packet.isEmpty())
+                        logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa Rx","---> %s", packet.c_str());
+                    receivedLoraPacket.text       = packet;
+                    receivedLoraPacket.rssi       = radio.getRSSI();
+                    receivedLoraPacket.snr        = radio.getSNR();
+                    receivedLoraPacket.freqError  = radio.getFrequencyError();
+                    break;
+                case RADIOLIB_ERR_RX_TIMEOUT:
+                   // timeout occurred while waiting for a packet
+                    break;
+                case RADIOLIB_ERR_CRC_MISMATCH:
+                    Serial.println(F("CRC error!"));
+                    break;
+                default:
+                    Serial.print(F("failed, code "));
+                    Serial.println(state);
             }
         }
         #endif

--- a/src/menu_utils.cpp
+++ b/src/menu_utils.cpp
@@ -522,12 +522,10 @@ namespace MENU_Utils {
                     } else {
                         thirdRowMainMenu = String(Utils::getMaidenheadLocator(gps.location.lat(), gps.location.lng(), 8));
                         thirdRowMainMenu += " LoRa[";
-                        if (loraIndex == 0) {
-                            thirdRowMainMenu += "Eu]";
-                        } else if (loraIndex == 1) {
-                            thirdRowMainMenu += "PL]";
-                        } else if (loraIndex == 2) {
-                            thirdRowMainMenu += "UK]";
+                        switch (loraIndex) {
+                            case 0: thirdRowMainMenu += "Eu]"; break;
+                            case 1: thirdRowMainMenu += "PL]"; break;
+                            case 2: thirdRowMainMenu += "UK]"; break;
                         }
                     }
                     
@@ -627,9 +625,9 @@ namespace MENU_Utils {
                             sixthRowMainMenu = "Battery  " + String(batteryVoltage) + "V   " + batteryCharge + "%";
                         }
                     #endif
-                } else {
+                } else
                     sixthRowMainMenu = "No Battery Connected" ;
-                }
+
                 show_display(firstRowMainMenu,
                              secondRowMainMenu,
                              thirdRowMainMenu,

--- a/src/menu_utils.cpp
+++ b/src/menu_utils.cpp
@@ -523,9 +523,10 @@ namespace MENU_Utils {
                         thirdRowMainMenu = String(Utils::getMaidenheadLocator(gps.location.lat(), gps.location.lng(), 8));
                         thirdRowMainMenu += " LoRa[";
                         switch (loraIndex) {
-                            case 0: thirdRowMainMenu += "Eu]"; break;
-                            case 1: thirdRowMainMenu += "PL]"; break;
-                            case 2: thirdRowMainMenu += "UK]"; break;
+                            case 0:  thirdRowMainMenu += "Eu]"; break;
+                            case 1:  thirdRowMainMenu += "PL]"; break;
+                            case 2:  thirdRowMainMenu += "UK]"; break;
+                            default: thirdRowMainMenu += "??]";
                         }
                     }
                     
@@ -625,9 +626,9 @@ namespace MENU_Utils {
                             sixthRowMainMenu = "Battery  " + String(batteryVoltage) + "V   " + batteryCharge + "%";
                         }
                     #endif
-                } else
+                } else {
                     sixthRowMainMenu = "No Battery Connected" ;
-
+                }
                 show_display(firstRowMainMenu,
                              secondRowMainMenu,
                              thirdRowMainMenu,

--- a/src/menu_utils.cpp
+++ b/src/menu_utils.cpp
@@ -630,12 +630,12 @@ namespace MENU_Utils {
                 } else {
                     sixthRowMainMenu = "No Battery Connected" ;
                 }
-                show_display(String(firstRowMainMenu),
-                            String(secondRowMainMenu),
-                            String(thirdRowMainMenu),
-                            String(fourthRowMainMenu),
-                            String(fifthRowMainMenu),
-                            String(sixthRowMainMenu));
+                show_display(firstRowMainMenu,
+                             secondRowMainMenu,
+                             thirdRowMainMenu,
+                             fourthRowMainMenu,
+                             fifthRowMainMenu,
+                             sixthRowMainMenu);
                 break;
         }
     }


### PR DESCRIPTION
A small refactor of the main menu display.
An else-if cascade turned into a switch-case.
`String` move constructor no longer called at the end of `showOnScreen()`.