### PR TITLE
Support board without GPS

### DIFF
--- a/src/gps_utils.cpp
+++ b/src/gps_utils.cpp
@@ -39,7 +39,7 @@ float       bearing                 = 0;
 namespace GPS_Utils {
 
     void setup() {
-        #if defined(TTGO_T_LORA32_V2_1_TNC) || defined(TTGO_T_LORA32_V2_1_TNC_915)
+        #if defined(TTGO_T_LORA32_V2_1_TNC) || defined(TTGO_T_LORA32_V2_1_TNC_915) || defined(HAS_NO_GPS)
             disableGPS = true;
         #else
             disableGPS = Config.disableGPS;


### PR DESCRIPTION
I trying add support for my Olab boards where I do not have GPS, so it will fail to start, this add build option to disable GPS if board does not have it.