### PR TITLE
Support modules with XTAL

### DIFF
--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -79,6 +79,9 @@ namespace LoRa_Utils {
         logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, "LoRa", "Set SPI pins!");
         SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
         float freq = (float)currentLoRaType->frequency/1000000;
+        #if defined(RADIO_HAS_XTAL)
+        radio.XTAL = true;
+        #endif
         int state = radio.begin(freq);
         if (state == RADIOLIB_ERR_NONE) {
             #if defined(HAS_SX1262) || defined(HAS_SX1268)

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -90,7 +90,7 @@ namespace LoRa_Utils {
             logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa", "Initializing SX127X ...");
             #endif
         } else {
-            logger.log(logging::LoggerLevel::LOGGER_LEVEL_ERROR, "LoRa", "Starting LoRa failed!");
+            logger.log(logging::LoggerLevel::LOGGER_LEVEL_ERROR, "LoRa", "Starting LoRa failed! State: %d", state);
             while (true);
         }
         #if defined(HAS_SX1262) || defined(HAS_SX1268)


### PR DESCRIPTION
I making custom board for tracker and later mainly for iGate. I am using now SX1268 radio module which does not use TCXO but XTAL. https://www.aliexpress.com/item/1005005715303224.html

This add build time flag to tell RadioLib to use XTAL instead of TCXO.

Also one commit add error code from begin, which was helpful to se error -707

https://github.com/jgromes/RadioLib/issues/99

