### PR TITLE
added LLCC68 (Ebyte E220-400M30S 1W LoRa) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ ____________________________________________________
 ____________________________________________________
 ## Timeline (Versions):
 
+- 2024.07.27 Added support for EByte E220 400M30S 1Watt LoRa module for DIY ESP32 Tracker: LLCC68 supports spreading factor only in range of 5-11!
 - 2024.07.01 All boards with 433MHZ and 915MHz versions now.
 - 2024.06.21 3rd Party Packets decode added following the corrections on iGate Firmware.
 - 2024.06.21 If Tracker Speed > 200km/hr and/or Altitude > 9.000 mts , path ("WIDE1-1") will be omited as its probably a plane.

--- a/platformio.ini
+++ b/platformio.ini
@@ -397,6 +397,20 @@ lib_deps =
 	adafruit/Adafruit SSD1306 @ 2.5.10
 	adafruit/Adafruit SH110X @ 2.1.10
 
+[env:ESP32_DIY_1W_LoRa_GPS_LLCC68]
+extends = env:esp32
+board = esp32dev
+build_flags = 
+	-Werror -Wall
+	-DESP32_DIY_1W_LoRa_GPS_LLCC68
+	-DHAS_LLCC68
+	-DHAS_1W_LORA
+	-DHAS_BT_CLASSIC
+lib_deps = 
+	${common.lib_deps}
+	adafruit/Adafruit GFX Library @ 1.11.9
+	adafruit/Adafruit SSD1306 @ 2.5.10
+	adafruit/Adafruit SH110X @ 2.1.10
 
 [env:OE5HWN_MeshCom]
 extends = env:esp32

--- a/src/boards_pinout.h
+++ b/src/boards_pinout.h
@@ -165,7 +165,7 @@
 #endif
 
 
-#if defined(ESP32_DIY_1W_LoRa_GPS) || defined(ESP32_DIY_1W_LoRa_GPS_915)
+#if defined(ESP32_DIY_1W_LoRa_GPS) || defined(ESP32_DIY_1W_LoRa_GPS_915) || defined(ESP32_DIY_1W_LoRa_GPS_LLCC68)
     #define OLED_SDA            21
     #define OLED_SCL            22
     #define OLED_RST            16

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -28,6 +28,9 @@ bool transmitFlag    = true;
 #if defined(HAS_SX1276)
     SX1276 radio = new Module(RADIO_CS_PIN, RADIO_BUSY_PIN, RADIO_RST_PIN);
 #endif
+#if defined(HAS_LLCC68)
+    LLCC68 radio = new Module(RADIO_CS_PIN, RADIO_DIO1_PIN, RADIO_RST_PIN, RADIO_BUSY_PIN);
+#endif
 
 namespace LoRa_Utils {
 
@@ -83,6 +86,8 @@ namespace LoRa_Utils {
         if (state == RADIOLIB_ERR_NONE) {
             #if defined(HAS_SX1262) || defined(HAS_SX1268)
             logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa", "Initializing SX126X ...");
+            #elif defined(HAS_LLCC68)
+            logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa", "Initializing LLCC68 ...");
             #else
             logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa", "Initializing SX127X ...");
             #endif
@@ -90,7 +95,7 @@ namespace LoRa_Utils {
             logger.log(logging::LoggerLevel::LOGGER_LEVEL_ERROR, "LoRa", "Starting LoRa failed!");
             while (true);
         }
-        #if defined(HAS_SX1262) || defined(HAS_SX1268)
+        #if defined(HAS_SX1262) || defined(HAS_SX1268) || defined(HAS_LLCC68)
             radio.setDio1Action(setFlag);
         #endif
         #if defined(HAS_SX1278) || defined(HAS_SX1276)
@@ -121,7 +126,7 @@ namespace LoRa_Utils {
             radio.setCurrentLimit(100); // to be validated (80 , 100)?
         #endif
 
-        #if defined(HAS_SX1262) || defined(HAS_SX1268)
+        #if defined(HAS_SX1262) || defined(HAS_SX1268) || defined(HAS_LLCC68)
         radio.setRxBoostedGainMode(true);
         #endif
 

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -28,7 +28,7 @@ bool transmitFlag    = true;
 #if defined(HAS_SX1276)
     SX1276 radio = new Module(RADIO_CS_PIN, RADIO_BUSY_PIN, RADIO_RST_PIN);
 #endif
-#if defined(HAS_LLCC68)
+#if defined(HAS_LLCC68) //LLCC68 supports spreading factor only in range of 5-11!
     LLCC68 radio = new Module(RADIO_CS_PIN, RADIO_DIO1_PIN, RADIO_RST_PIN, RADIO_BUSY_PIN);
 #endif
 
@@ -111,7 +111,7 @@ namespace LoRa_Utils {
             radio.setRfSwitchPins(RADIO_RXEN, RADIO_TXEN);
         #endif
 
-        #ifdef HAS_1W_LORA  // Ebyte E22 400M30S (SX1268) / 900M30S (SX1262)
+        #ifdef HAS_1W_LORA  // Ebyte E22 400M30S (SX1268) / 900M30S (SX1262) / Ebyte E220 400M30S (LLCC68)
             state = radio.setOutputPower(currentLoRaType->power); // max value 20 (when 20dB in setup 30dB in output as 400M30S has Low Noise Amp)
             radio.setCurrentLimit(140); // to be validated (100 , 120, 140)?
         #endif

--- a/src/power_utils.cpp
+++ b/src/power_utils.cpp
@@ -72,7 +72,7 @@ namespace POWER_Utils {
                 batteryMeasurmentTime = millis();
             #endif
                 double voltage = (adc_value * 3.3 ) / 4095.0;
-            #if defined(TTGO_T_Beam_V0_7) || defined(TTGO_T_LORA32_V2_1_GPS) || defined(TTGO_T_LORA32_V2_1_GPS_915) || defined(TTGO_T_LORA32_V2_1_TNC) || defined(TTGO_T_LORA32_V2_1_TNC_915) || defined(ESP32_DIY_LoRa_GPS) || defined(ESP32_DIY_LoRa_GPS_915) || defined(ESP32_DIY_1W_LoRa_GPS) || defined(ESP32_DIY_1W_LoRa_GPS_915) || defined(OE5HWN_MeshCom) || defined(TTGO_T_DECK_GPS)
+            #if defined(TTGO_T_Beam_V0_7) || defined(TTGO_T_LORA32_V2_1_GPS) || defined(TTGO_T_LORA32_V2_1_GPS_915) || defined(TTGO_T_LORA32_V2_1_TNC) || defined(TTGO_T_LORA32_V2_1_TNC_915) || defined(ESP32_DIY_LoRa_GPS) || defined(ESP32_DIY_LoRa_GPS_915) || defined(ESP32_DIY_1W_LoRa_GPS_LLCC68) || defined(ESP32_DIY_1W_LoRa_GPS) || defined(ESP32_DIY_1W_LoRa_GPS_915) || defined(OE5HWN_MeshCom) || defined(TTGO_T_DECK_GPS)
                 return (2 * (voltage + 0.1)) * (1 + (lora32BatReadingCorr/100)); // (2 x 100k voltage divider) 2 x voltage divider/+0.1 because ESP32 nonlinearity ~100mV ADC offset/extra correction
             #endif
             #if defined(HELTEC_V3_GPS) || defined(HELTEC_WIRELESS_TRACKER) || defined(ESP32_C3_DIY_LoRa_GPS) || defined(ESP32_C3_DIY_LoRa_GPS_915) || defined(WEMOS_ESP32_Bat_LoRa_GPS)


### PR DESCRIPTION
By accident bought E220 instead E22, but with updated RadioLib and simple edit of current code it is now possible to use it. Tested in a tracker for a few days.