### PR TITLE
Added comment for when you change callsign.

### DIFF
--- a/data/tracker_config.json
+++ b/data/tracker_config.json
@@ -9,7 +9,7 @@
 			"comment": "",
 			"smartBeaconActive": true,
 			"smartBeaconSetting": 0,
-			"callchangecomment": ""
+			"profilelabel": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -20,7 +20,7 @@
 			"comment": "",
 			"smartBeaconActive": true,
 			"smartBeaconSetting": 2,
-			"callchangecomment": ""
+			"profilelabel": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -31,7 +31,7 @@
 			"comment": "",
 			"smartBeaconActive": true,
 			"smartBeaconSetting": 1,
-			"callchangecomment": ""
+			"profilelabel": ""
 		}
 	],
 	"display": {

--- a/data/tracker_config.json
+++ b/data/tracker_config.json
@@ -8,7 +8,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 0	
+			"smartBeaconSetting": 0,
+			"callchangecomment": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -18,7 +19,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 2
+			"smartBeaconSetting": 2,
+			"callchangecomment": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -28,7 +30,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 1
+			"smartBeaconSetting": 1,
+			"callchangecomment": ""
 		}
 	],
 	"display": {

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -36,7 +36,7 @@ void Configuration::readFile(fs::FS &fs, const char *fileName) {
         bcn.smartBeaconSetting      = BeaconsArray[i]["smartBeaconSetting"] | 0;
         bcn.micE                    = BeaconsArray[i]["micE"] | "";
         bcn.gpsEcoMode              = BeaconsArray[i]["gpsEcoMode"] | false;
-        bcn.callchangecomment       = BeaconsArray[i]["callchangecomment"] | "";
+        bcn.profilelabel            = BeaconsArray[i]["profilelabel"] | "";
         
         beacons.push_back(bcn);
     }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -36,6 +36,7 @@ void Configuration::readFile(fs::FS &fs, const char *fileName) {
         bcn.smartBeaconSetting      = BeaconsArray[i]["smartBeaconSetting"] | 0;
         bcn.micE                    = BeaconsArray[i]["micE"] | "";
         bcn.gpsEcoMode              = BeaconsArray[i]["gpsEcoMode"] | false;
+        bcn.callchangecomment       = BeaconsArray[i]["callchangecomment"] | "";
         
         beacons.push_back(bcn);
     }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -15,6 +15,7 @@ public:
     byte    smartBeaconSetting;
     String  micE;
     bool    gpsEcoMode;
+    String  callchangecomment;
 };
 
 class Display {

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -15,7 +15,7 @@ public:
     byte    smartBeaconSetting;
     String  micE;
     bool    gpsEcoMode;
-    String  callchangecomment;
+    String  profilelabel;
 };
 
 class Display {

--- a/src/keyboard_utils.cpp
+++ b/src/keyboard_utils.cpp
@@ -77,7 +77,7 @@ int         downCounter             = 0;
 int         leftCounter             = 0;
 int         rightCounter            = 0;
 int         trackBallSensitivity    = 5;
-String callchangecomment            = "";
+String      profilelabel            = "";
 
 
 namespace KEYBOARD_Utils {
@@ -336,13 +336,13 @@ namespace KEYBOARD_Utils {
             statusState  = true;
             statusTime = millis();
             winlinkCommentState = false;
-            if(strlen(Config.beacons[myBeaconsIndex].callchangecomment.c_str()) >0 ){ //if length of the callchangecomment is > 0 then print the comment when changing callsign. Else don't.
-                callchangecomment = " (" + Config.beacons[myBeaconsIndex].callchangecomment + ")";
+            if(strlen(Config.beacons[myBeaconsIndex].profilelabel.c_str()) >0 ){ //if length of the profilelabel is > 0 then print the comment when changing callsign. Else don't.
+                profilelabel = " (" + Config.beacons[myBeaconsIndex].profilelabel + ")";
             }
             else{
-                callchangecomment = "";
+                profilelabel = "";
             }
-            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "--> " + Config.beacons[myBeaconsIndex].callsign + callchangecomment, "", 2000);
+            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "--> " + Config.beacons[myBeaconsIndex].callsign + profilelabel, "", 2000);
             STATION_Utils::saveIndex(0, myBeaconsIndex);
             if (menuDisplay == 200) {
                 menuDisplay = 20;

--- a/src/keyboard_utils.cpp
+++ b/src/keyboard_utils.cpp
@@ -77,6 +77,7 @@ int         downCounter             = 0;
 int         leftCounter             = 0;
 int         rightCounter            = 0;
 int         trackBallSensitivity    = 5;
+String callchangecomment            = "";
 
 
 namespace KEYBOARD_Utils {
@@ -335,7 +336,13 @@ namespace KEYBOARD_Utils {
             statusState  = true;
             statusTime = millis();
             winlinkCommentState = false;
-            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "-----> " + Config.beacons[myBeaconsIndex].callsign, "", 2000);
+            if(strlen(Config.beacons[myBeaconsIndex].callchangecomment.c_str()) >0 ){ //if length of the callchangecomment is > 0 then print the comment when changing callsign. Else don't.
+                callchangecomment = " (" + Config.beacons[myBeaconsIndex].callchangecomment + ")";
+            }
+            else{
+                callchangecomment = "";
+            }
+            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "--> " + Config.beacons[myBeaconsIndex].callsign + callchangecomment, "", 2000);
             STATION_Utils::saveIndex(0, myBeaconsIndex);
             if (menuDisplay == 200) {
                 menuDisplay = 20;


### PR DESCRIPTION
While programming the tracker for a friend who wanted to have some other APRS icons used rather than the ones that are used in the default config I noticed that not all icons are implemented in the software.  I do not think it would be needed to implement those, but I got an idea that it might help  to have comment printed on display during the callsign change. 

Additional parameter has been added to the data json: **callchangecomment**. If this parameter exists it is shown on the display during the callsign change.

I think this might be better solutions as this comment can be used also for some other differences rather than only callsign icon. For example someone might like to have same callsign with same icon but different smart Beaconing settings. 