### PR TITLE
BLE TNC improvements

### DIFF
--- a/data/tracker_conf.json
+++ b/data/tracker_conf.json
@@ -50,7 +50,8 @@
 		"rememberStationTime": 30,
 		"standingUpdateTime": 15,
 		"sendAltitude": true,
-		"disableGPS": false
+		"disableGPS": false,
+		"acceptOwnFrameFromTNC": false
 	},
 	"winlink": {
 		"password": "ABCDEF"

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -182,7 +182,7 @@ void loop() {
 
     ReceivedLoRaPacket packet = LoRa_Utils::receivePacket();
 
-    if (Config.bluetoothType == 0 || Config.bluetoothType == 2) {
+    if (Config.bluetooth.type == 0 || Config.bluetooth.type == 2) {
         BLE_Utils::sendToPhone(packet.text.substring(3));
     } else {
         #ifdef HAS_BT_CLASSIC

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -180,7 +180,17 @@ void loop() {
         KEYBOARD_Utils::mouseRead();
     #endif
 
-    MSG_Utils::checkReceivedMessage(LoRa_Utils::receivePacket());
+    ReceivedLoRaPacket packet = LoRa_Utils::receivePacket();
+
+    if (Config.bluetoothType == 0 || Config.bluetoothType == 2) {
+        BLE_Utils::sendToPhone(packet.text.substring(3));
+    } else {
+        #ifdef HAS_BT_CLASSIC
+        BLUETOOTH_Utils::sendPacket(packet.text.substring(3));
+        #endif
+    }
+
+    MSG_Utils::checkReceivedMessage(packet);
     MSG_Utils::processOutputBuffer();
     MSG_Utils::clean25SegBuffer();
     MSG_Utils::ledNotification();

--- a/src/ax25_utils.cpp
+++ b/src/ax25_utils.cpp
@@ -1,165 +1,172 @@
 #include "ax25_utils.h"
+#include "kiss_protocol.h"
 
 namespace AX25_Utils {
 
-    AX25Frame decodedFrame;
+    bool validateTNC2Frame(const String& tnc2FormattedFrame) {
+        return (tnc2FormattedFrame.indexOf(':') != -1) && (tnc2FormattedFrame.indexOf('>') != -1);
+    }
 
-    String decodeFrame(const String& frame) {
-        String packet = "";
-        for (int a = 0; a < 6; a ++) {
-            uint16_t shiftedValue = frame[a] >> 1;
-            if (shiftedValue == 32) {
-                a = 10;
+    bool validateKISSFrame(const String& kissFormattedFrame) {
+        return kissFormattedFrame.charAt(0) == (char)FEND && kissFormattedFrame.charAt(kissFormattedFrame.length() - 1) == (char)FEND;
+    }
+
+    String encodeAddressAX25(String tnc2Address) {
+        bool hasBeenDigipited = tnc2Address.indexOf('*') != -1;
+
+        if (tnc2Address.indexOf('-') == -1) {
+            if (hasBeenDigipited) {
+                tnc2Address = tnc2Address.substring(0, tnc2Address.length() - 1);
+            }
+
+            tnc2Address += "-0";
+        }
+
+        int separatorIndex = tnc2Address.indexOf('-');
+        int ssid = tnc2Address.substring(separatorIndex + 1).toInt();
+
+        String kissAddress = "";
+        for (int i = 0; i < 6; ++i) {
+            char addressChar;
+            if (tnc2Address.length() > i && i < separatorIndex) {
+                addressChar = tnc2Address.charAt(i);
             } else {
-                //Serial.print(char(shiftedValue));
-                packet += char(shiftedValue);
+                addressChar = ' ';
             }
+            kissAddress += (char)(addressChar << 1);
         }
-        byte ssid = (frame[6]>>1) & 0x0f;
-        if (String(ssid) != "0") {
-            packet += "-";
-            packet += String(ssid);
-        }
-        return packet;
+
+        kissAddress += (char)((ssid << 1) | 0b01100000 | (hasBeenDigipited ? HAS_BEEN_DIGIPITED_MASK : 0));
+        return kissAddress;
     }
 
-    bool decodeAX25(const String& frame, int frameSize, AX25Frame* decodedFrame) {
-        if ((frameSize < 14) || (frame[0] != KissChar::Fend && frame[1] != KissCmd::Data && frame[frameSize - 1] != KissChar::Fend)) {
-            return false;
-        }
-        int payloadFrameStart = 0;
-        for (int i = 0; i < frameSize; i++) {                   // where is CONTROL y PID ?
-            if (frame[i] == 0x03 && frame[i+1] == 0xf0) {
-                payloadFrameStart = i+1;
+    String decodeAddressAX25(const String& ax25Address, bool& isLast, bool isRelay) {
+        String address = "";
+        for (int i = 0; i < 6; ++i) {
+            uint8_t currentCharacter = ax25Address.charAt(i);
+            currentCharacter >>= 1;
+            if (currentCharacter != ' ') {
+                address += (char)currentCharacter;
             }
         }
-        decodedFrame->tocall    = frame.substring(2, 9);      // Extract destination address
-        decodedFrame->sender    = frame.substring(9, 16);     // Extract source address
-        if (payloadFrameStart >= 21) {                    // is there path1?
-            decodedFrame->path1 = frame.substring(16, 23);
+        auto ssidChar = (uint8_t)ax25Address.charAt(6);
+        bool hasBeenDigipited = ssidChar & HAS_BEEN_DIGIPITED_MASK;
+        isLast = ssidChar & IS_LAST_ADDRESS_POSITION_MASK;
+        ssidChar >>= 1;
+
+        int ssid = 0b1111 & ssidChar;
+
+        if (ssid) {
+            address += '-';
+            address += ssid;
         }
-        if (payloadFrameStart >= 28) {                    // is there path2?
-            decodedFrame->path2 = frame.substring(23, 30);
+        if (isRelay && hasBeenDigipited) {
+            address += '*';
         }
-        decodedFrame->control   = frame.substring(payloadFrameStart-1, payloadFrameStart);   // Extract control information  // 0x03
-        decodedFrame->pid       = frame.substring(payloadFrameStart, payloadFrameStart + 1);       // Extract pid information      // 0xF0
-        decodedFrame->payload   = frame.substring(payloadFrameStart + 1, frameSize - 1);         // Extract payload
-        return true;
+
+        return address;
     }
 
-    String AX25FrameToLoRaPacket(const String& frame) {
-        //Serial.println(frame);
-        if (decodeAX25(frame, frame.length(), &decodedFrame)) {
-            //String packetToLoRa = "";
-            String packetToLoRa = decodeFrame(decodedFrame.sender) + ">" + decodeFrame(decodedFrame.tocall);
+    String encapsulateKISS(const String& ax25Frame, uint8_t cmd) {
+        String kissFrame = "";
+        kissFrame += (char)FEND;
+        kissFrame += (char)(0x0f & cmd);
 
-            if (decodedFrame.path1[0] != 0) {
-                packetToLoRa += ",";
-                packetToLoRa += decodeFrame(decodedFrame.path1);
+        for (int i = 0; i < ax25Frame.length(); ++i) {
+            char currentChar = ax25Frame.charAt(i);
+            if (currentChar == (char)FEND) {
+                kissFrame += (char)FESC;
+                kissFrame += (char)TFEND;
+            } else if (currentChar == (char)FESC) {
+                kissFrame += (char)FESC;
+                kissFrame += (char)TFESC;
+            } else {
+                kissFrame += currentChar;
             }
-            if (decodedFrame.path2[0] != 0) {
-                packetToLoRa += ",";
-                packetToLoRa += decodeFrame(decodedFrame.path2);
-            }
-            packetToLoRa += ":";
-            packetToLoRa += decodedFrame.payload;
-            return packetToLoRa;
-        } else {
-            return "";
         }
+        kissFrame += (char)FEND; // end of frame
+        return kissFrame;
     }
 
-    String frameCleaning(const String& frameToClean) {
-        String frame = frameToClean;
-        if (frame.length() > 6) {
-            frame = frame.substring(0, 6);
-        } else if (frame.length() < 6) {
-            for (int i = 0; frame.length() < 6; i++) { 
-                frame += " ";
+    String decapsulateKISS(const String& frame) {
+        String ax25Frame = "";
+        for (int i = 2; i < frame.length() - 1; ++i) {
+            char currentChar = frame.charAt(i);
+            if (currentChar == (char)FESC) {
+                char nextChar = frame.charAt(i + 1);
+                if (nextChar == (char)TFEND) {
+                    ax25Frame += (char)FEND;
+                } else if (nextChar == (char)TFESC) {
+                    ax25Frame += (char)FESC;
+                }
+                i++;
+            } else {
+                ax25Frame += currentChar;
             }
         }
+
+        return ax25Frame;
+    }
+
+    String encodeKISS(const String& frame) {
+        String ax25Frame = "";
+
+        if (validateTNC2Frame(frame)) {
+            String address = "";
+            bool dstAddresWritten = false;
+            for (int p = 0; p <= frame.indexOf(':'); p++) {
+                char currentChar = frame.charAt(p);
+                if (currentChar == ':' || currentChar == '>' || currentChar == ',') {
+                    if (!dstAddresWritten && (currentChar == ',' || currentChar == ':')) {
+                        ax25Frame = encodeAddressAX25(address) + ax25Frame;
+                        dstAddresWritten = true;
+                    } else {
+                        ax25Frame += encodeAddressAX25(address);
+                    }
+                    address = "";
+                } else {
+                    address += currentChar;
+                }
+            }
+
+            auto lastAddressChar = (uint8_t)ax25Frame.charAt(ax25Frame.length() - 1);
+            ax25Frame.setCharAt(ax25Frame.length() - 1, (char)(lastAddressChar | IS_LAST_ADDRESS_POSITION_MASK));
+            ax25Frame += (char)APRS_CONTROL_FIELD;
+            ax25Frame += (char)APRS_INFORMATION_FIELD;
+            ax25Frame += frame.substring(frame.indexOf(':') + 1);
+        }
+
+        String kissFrame = encapsulateKISS(ax25Frame, CMD_DATA);
+        return kissFrame;
+    }
+
+    String decodeKISS(const String& inputFrame, bool& dataFrame) {
+        String frame = "";
+
+        if (validateKISSFrame(inputFrame)) {
+            dataFrame = inputFrame.charAt(1) == CMD_DATA;
+            if (dataFrame) {
+                String ax25Frame = decapsulateKISS(inputFrame);
+                bool isLast = false;
+                String dstAddr = decodeAddressAX25(ax25Frame.substring(0, 7), isLast, false);
+                String srcAddr = decodeAddressAX25(ax25Frame.substring(7, 14), isLast, false);
+
+                frame = srcAddr + ">" + dstAddr;
+
+                int digiInfoIndex = 14;
+                while (!isLast && digiInfoIndex + 7 < ax25Frame.length()) {
+                    String digiAddr = decodeAddressAX25(ax25Frame.substring(digiInfoIndex, digiInfoIndex + 7), isLast, true);
+                    frame += ',' + digiAddr;
+                    digiInfoIndex += 7;
+                }
+
+                frame += ':';
+                frame += ax25Frame.substring(digiInfoIndex + 2);
+            } else {
+                frame += inputFrame;
+            }
+        }
+
         return frame;
     }
-
-    std::string intToBinaryString(uint8_t value, const uint8_t bitLength) {
-        std::string result = "";
-        //result.reserve(bitLength);
-        for (int i = bitLength - 1; i >= 0; i--) {
-            result += ((value >> i) & 1) ? '1' : '0';
-        }
-        return result;
-    }
-
-    String encodeAX25Address(const String& frame, uint8_t type, const bool lastAddress) {
-        String address;
-        int ssid;
-        if (frame.indexOf("-") > 0) {
-            address = frameCleaning(frame.substring(0, frame.indexOf("-")));
-            ssid = frame.substring(frame.indexOf("-") + 1).toInt();
-            if (ssid > 15) {
-                ssid = 0;
-            }
-        } else {
-            address = frameCleaning(frame);
-            ssid = 0;
-        }
-        String packet = "";
-        for (int j = 0; j < 6; j++) {
-            char c = address[j];
-            packet += char(c<<1);
-        }
-        std::string firstSSIDBit = std::to_string(type); //type=0 (sender or path not repeated) type=1 (tocall or path being repeated)
-        std::string lastSSIDBit = "0";
-        if (lastAddress) {
-            lastSSIDBit = "1";          // address is the last from AX.25 Frame
-        }
-        std::string concatenatedBinary = firstSSIDBit + "11" + intToBinaryString(ssid,4) + lastSSIDBit; // ( CRRSSSSX / HRRSSSSX )
-        long decimalValue = strtol(concatenatedBinary.c_str(), NULL, 2);
-        packet += (char)decimalValue;   //SSID 
-        return packet;
-    }
-
-    String LoRaPacketToAX25Frame(const String& packet) {
-        //String encodedPacket    = "";
-        //String tocall           = "";
-        String  sender      = packet.substring(0, packet.indexOf(">"));
-        bool    lastAddress = false;
-        //String  payload     = packet.substring(packet.indexOf(":") + 1);
-        String  temp        = packet.substring(packet.indexOf(">") + 1, packet.indexOf(":"));
-
-        String tocall;
-        if (temp.indexOf(",") != -1) {    
-            tocall      = temp.substring(0, temp.indexOf(","));
-            temp        = temp.substring(temp.indexOf(",") + 1);
-        } else {
-            tocall      = temp;
-            temp        = "";
-            lastAddress = true;
-        }
-        String encodedPacket = encodeAX25Address(tocall, 1, false);
-        encodedPacket += encodeAX25Address(sender, 0, lastAddress);
-
-        while (temp.length() > 0) {
-            String address;
-            if (temp.indexOf(",") > 0) {
-                address     = temp.substring(0, temp.indexOf(","));
-                temp        = temp.substring(temp.indexOf(",") + 1);
-            } else {
-                address     = temp;
-                temp        = "";
-                lastAddress = true;        
-            }
-            int repeatedPath = 0;
-            if (address.indexOf("*") > 0) {
-                repeatedPath = 1;
-            }
-            encodedPacket += encodeAX25Address(address, repeatedPath, lastAddress);
-        }
-
-        encodedPacket += char(0x03);
-        encodedPacket += char(0xF0);
-        encodedPacket += packet.substring(packet.indexOf(":") + 1);
-        return encodedPacket;
-    }
-
 }

--- a/src/ax25_utils.h
+++ b/src/ax25_utils.h
@@ -3,45 +3,10 @@
 
 #include <Arduino.h>
 
-struct AX25Frame {  // Define AX.25 frame structure
-    String tocall;    // destination
-    String sender;    // source
-    String path1;     // if present
-    String path2;     // if present
-    String control;
-    String pid;
-    String payload;
-};
-
-enum KissChar {
-    Fend                = 0xc0,
-    Fesc                = 0xdb,
-    Tfend               = 0xdc,
-    Tfesc               = 0xdd
-};
-
-enum KissCmd {
-    Data                = 0x00,
-    TxDelay             = 0x01,
-    P                   = 0x02,
-    SlotTime            = 0x03,
-    TxTail              = 0x04,
-    SetHardware         = 0x06,
-    SignalReport        = 0x07,
-    RebootRequested     = 0x08,
-    Telemetry           = 0x09,
-    NoCmd               = 0x80
-};
-
 namespace AX25_Utils {
 
-    String          decodeFrame(const String& frame);
-    bool            decodeAX25(const String& frame, int frameSize, AX25Frame* decodedFrame);
-    String          AX25FrameToLoRaPacket(const String& frame);
-    String          frameCleaning(const String& frameToClean);
-    std::string     intToBinaryString(uint8_t value, const uint8_t bitLength);
-    String          encodeAX25Address(const String& frame, uint8_t type, const bool lastAddress);
-    String          LoRaPacketToAX25Frame(const String& packet);
+    String          encodeKISS(const String& frame);
+    String          decodeKISS(const String& inputFrame, bool& dataFrame);
 
 }
 

--- a/src/ble_utils.cpp
+++ b/src/ble_utils.cpp
@@ -139,6 +139,17 @@ namespace BLE_Utils {
         if (!sendBleToLoRa) {
             return;
         }
+
+        if (!Config.acceptOwnFrameFromTNC && BLEToLoRaPacket.indexOf("::") == -1) {
+            String sender = BLEToLoRaPacket.substring(0,BLEToLoRaPacket.indexOf(">"));
+
+            if (sender == currentBeacon->callsign) {
+                BLEToLoRaPacket = "";
+                sendBleToLoRa = false;
+                return;
+            }
+        }
+
         logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, "BLE Tx", "%s", BLEToLoRaPacket.c_str());
         displayShow("BLE Tx >>", "", BLEToLoRaPacket, 1000);
         LoRa_Utils::sendNewPacket(BLEToLoRaPacket);

--- a/src/ble_utils.cpp
+++ b/src/ble_utils.cpp
@@ -50,7 +50,7 @@ String kissSerialBuffer = "";
 
 class MyCallbacks : public NimBLECharacteristicCallbacks {
     void onWrite(NimBLECharacteristic *pCharacteristic) {
-        if (Config.bluetoothType == 2) { // TNC2
+        if (Config.bluetooth.type == 2) { // TNC2
             std::string receivedData = pCharacteristic->getValue();
             String receivedString = "";
             for (int i = 0; i < receivedData.length(); i++) {
@@ -59,7 +59,7 @@ class MyCallbacks : public NimBLECharacteristicCallbacks {
             
             BLEToLoRaPacket = receivedString;
             sendBleToLoRa = true;
-        } else if (Config.bluetoothType == 0) { // AX25 KISS
+        } else if (Config.bluetooth.type == 0) { // AX25 KISS
             std::string receivedData = pCharacteristic->getValue();
 
             delay(100);
@@ -164,7 +164,7 @@ namespace BLE_Utils {
     }
 
     void txToPhoneOverBLE(const String& frame) {
-        if (Config.bluetoothType == 0) { // AX25 KISS
+        if (Config.bluetooth.type == 0) { // AX25 KISS
             const String kissEncoded = AX25_Utils::encodeKISS(frame);
 
             const char* t = kissEncoded.c_str();

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -181,6 +181,7 @@ bool Configuration::readFile() {
         standingUpdateTime              = data["other"]["standingUpdateTime"] | 15;
         sendAltitude                    = data["other"]["sendAltitude"] | true;
         disableGPS                      = data["other"]["disableGPS"] | false;
+        acceptOwnFrameFromTNC           = data["other"]["acceptOwnFrameFromTNC"] | false;
 
         configFile.close();
         Serial.println("Config read successfuly");
@@ -302,6 +303,7 @@ void Configuration::init() {
     standingUpdateTime              = 15;
     sendAltitude                    = true;
     disableGPS                      = false;
+    acceptOwnFrameFromTNC           = false;
 
     Serial.println("New Data Created...");
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -116,6 +116,7 @@ public:
     int     standingUpdateTime;
     bool    sendAltitude;
     bool    disableGPS;
+    bool    acceptOwnFrameFromTNC;
 
     void init();
     void writeFile();

--- a/src/kiss_protocol.h
+++ b/src/kiss_protocol.h
@@ -1,0 +1,23 @@
+#define DCD_ON            0x03
+
+#define FEND              0xC0
+#define FESC              0xDB
+#define TFEND             0xDC
+#define TFESC             0xDD
+
+#define CMD_UNKNOWN       0xFE
+#define CMD_DATA          0x00
+#define CMD_HARDWARE      0x06
+
+#define HW_RSSI           0x21
+
+#define CMD_ERROR         0x90
+#define ERROR_INITRADIO   0x01
+#define ERROR_TXFAILED    0x02
+#define ERROR_QUEUE_FULL  0x04
+
+#define APRS_CONTROL_FIELD 0x03
+#define APRS_INFORMATION_FIELD 0xf0
+
+#define HAS_BEEN_DIGIPITED_MASK 0b10000000
+#define IS_LAST_ADDRESS_POSITION_MASK 0b1

--- a/src/msg_utils.cpp
+++ b/src/msg_utils.cpp
@@ -6,7 +6,6 @@
 #include "winlink_utils.h"
 #include "configuration.h"
 #include "lora_utils.h"
-#include "ble_utils.h"
 #include "msg_utils.h"
 #include "gps_utils.h"
 #include "display.h"
@@ -417,14 +416,6 @@ namespace MSG_Utils {
                 }
 
                 if (check25SegBuffer(lastReceivedPacket.sender, lastReceivedPacket.message)) {
-                    if (Config.bluetooth.type == 0 || Config.bluetooth.type == 2) { // agregar validador si cliente BLE esta conectado?
-                        BLE_Utils::sendToPhone(packet.text.substring(3));
-                    } else {
-                        #ifdef HAS_BT_CLASSIC
-                        BLUETOOTH_Utils::sendPacket(packet.text.substring(3));
-                        #endif
-                    }                    
-
                     if (digirepeaterActive && lastReceivedPacket.addressee != currentBeacon->callsign) {
                         String digiRepeatedPacket = APRSPacketLib::generateDigiRepeatedPacket(packet.text, currentBeacon->callsign, Config.path);
                         if (digiRepeatedPacket == "X") {

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -11,6 +11,7 @@
 #include "bme_utils.h"
 #include "display.h"
 #include "logger.h"
+#include "ble_utils.h"
 
 extern Configuration        Config;
 extern Beacon               *currentBeacon;
@@ -278,6 +279,10 @@ namespace STATION_Utils {
         displayShow("<<< TX >>>", "", packet,100);
         LoRa_Utils::sendNewPacket(packet);
         
+        if (Config.bluetoothType == 0 || Config.bluetoothType == 2) {
+            BLE_Utils::sendToPhone(packet);
+        }
+
         if (smartBeaconActive) {
             lastTxLat       = gps.location.lat();
             lastTxLng       = gps.location.lng();

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -279,7 +279,7 @@ namespace STATION_Utils {
         displayShow("<<< TX >>>", "", packet,100);
         LoRa_Utils::sendNewPacket(packet);
         
-        if (Config.bluetoothType == 0 || Config.bluetoothType == 2) {
+        if (Config.bluetooth.type == 0 || Config.bluetooth.type == 2) {
             BLE_Utils::sendToPhone(packet);
         }
 


### PR DESCRIPTION
1. Always send own beacon to TNC, that works like in Thomas DL9SAU software
2. Send all received packets to TNC without any filtering, TNC RX and TX must be transparent
3. AX.25 KISS functions refactor, copied from IGate software (we want unification for the same features in both IGate and Tracker repos)
4. Ignore own beacon from TNC. Important option when we are using APRSDroid and we have the same SSID but we don't want beacon from APRSDroid to be send to RF
5. TNC KISS incoming buffer and sending in 64 bytes chunks

These changes will allow integration with APRSDroid via BLE :) 