### PR TITLE
Add interrupt support for the button

### DIFF
--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -13,7 +13,6 @@
 __________________________________________________________________________________________________________________________________*/
 
 #include <BluetoothSerial.h>
-#include <OneButton.h>
 #include <TinyGPS++.h>
 #include <Arduino.h>
 #include <logger.h>
@@ -44,9 +43,6 @@ HardwareSerial                      gpsSerial(1);
 TinyGPSPlus                         gps;
 #ifdef HAS_BT_CLASSIC
     BluetoothSerial                 SerialBT;
-#endif
-#ifdef BUTTON_PIN
-    OneButton userButton            = OneButton(BUTTON_PIN, true, true);
 #endif
 
 String      versionDate             = "2024.10.11";
@@ -139,10 +135,7 @@ void setup() {
 
     if (!Config.simplifiedTrackerMode) {
         #ifdef BUTTON_PIN
-            userButton.attachClick(BUTTON_Utils::singlePress);
-            userButton.attachLongPressStart(BUTTON_Utils::longPress);
-            userButton.attachDoubleClick(BUTTON_Utils::doublePress);
-            userButton.attachMultiClick(BUTTON_Utils::multiPress);
+            BUTTON_Utils::buttonInit();
         #endif
         KEYBOARD_Utils::setup();
     }
@@ -169,7 +162,7 @@ void loop() {
 
     if (!Config.simplifiedTrackerMode) {
         #ifdef BUTTON_PIN
-            userButton.tick();
+            BUTTON_Utils::buttonLoop();
         #endif
     }
 

--- a/src/button_utils.cpp
+++ b/src/button_utils.cpp
@@ -1,25 +1,45 @@
+#include <OneButton.h>
 #include "keyboard_utils.h"
+#include "boards_pinout.h"
 #include "button_utils.h"
 #include "power_utils.h"
 #include "display.h"
+
+#ifdef BUTTON_PIN
 
 extern int              menuDisplay;
 extern uint32_t         displayTime;
 extern uint32_t         menuTime;
 
 namespace BUTTON_Utils {
+    OneButton userButton            = OneButton(BUTTON_PIN, true, true);
 
-    void singlePress() {
+    // Button interrupt handler.
+    // Called every time the button is pressed or released
+    void IRAM_ATTR buttonIsr()
+    {
+        userButton.tick();
+    }
+
+    // Set to true by the interrupt handler if the function should
+    // be called in the main loop
+    static bool bSinglePress;
+    static bool bLongPress;
+    static bool bDoublePress;
+    static bool bMultiPress;
+
+    // Functions called from the main loop
+    static void singlePress() {
         menuTime = millis();
         KEYBOARD_Utils::downArrow();
     }
 
-    void longPress() {
+    static void longPress() {
         menuTime = millis();
         KEYBOARD_Utils::rightArrow();
     }
 
-    void doublePress() {
+    static void doublePress() {
         displayToggle(true);
         menuTime = millis();
         if (menuDisplay == 0) {
@@ -30,10 +50,79 @@ namespace BUTTON_Utils {
         }
     }
 
-    void multiPress() {
+    static void multiPress() {
         displayToggle(true);
         menuTime = millis();
         menuDisplay = 9000;
     }
 
+    // Functions called by the OneButton library from the interrupt handler
+    // These just trigger one of the above functions to be called from the main loop
+    void isrSinglePress()
+    {
+        bSinglePress = true;
+    }
+
+    void isrLongPress()
+    {
+        bLongPress = true;
+    }
+
+    void isrDoublePress()
+    {
+        bDoublePress = true;
+    }
+
+    void isrMultiPress()
+    {
+        bMultiPress = true;
+    }
+
+    // Called from the main loop
+    void buttonLoop()
+    {
+        // Call the button tick function
+        // Must be called with interrupts disabled as the OneButton
+        // library is called from the interrupt handler
+        noInterrupts();
+        userButton.tick();
+        interrupts();
+
+        // Call the relevant function if triggered by the interrupt handler
+        if( bSinglePress )
+        {
+            singlePress();
+            bSinglePress = false;
+        }
+
+        if( bLongPress )
+        {
+            longPress();
+            bLongPress = false;
+        }
+
+        if( bDoublePress )
+        {
+            doublePress();
+            bDoublePress = false;
+        }
+
+        if( bMultiPress )
+        {
+            multiPress();
+            bMultiPress = false;
+        }
+    }
+
+    void buttonInit()
+    {
+        userButton.attachClick(BUTTON_Utils::isrSinglePress);
+        userButton.attachLongPressStart(BUTTON_Utils::isrLongPress);
+        userButton.attachDoubleClick(BUTTON_Utils::isrDoublePress);
+        userButton.attachMultiClick(BUTTON_Utils::isrMultiPress);
+
+        attachInterrupt(BUTTON_PIN, buttonIsr, CHANGE);
+    }
 }
+
+#endif

--- a/src/button_utils.h
+++ b/src/button_utils.h
@@ -3,13 +3,10 @@
 
 #include <Arduino.h>
 
-namespace BUTTON_Utils {
-
-    void singlePress();
-    void longPress();
-    void doublePress();
-    void multiPress();
-
+namespace BUTTON_Utils
+{
+    void buttonInit();
+    void buttonLoop();
 }
 
 #endif


### PR DESCRIPTION
Adds an interrupt handler for the button so that the OneButton tick() function is called whenever the button is pressed or released as well as in the main loop. This ensures that single, double and triple clicks are all correctly recognised. The interrupt handler is needed as some of the processing in the main loop is very slow and clicks are missed making the user experience very frustrating.

Only tested on Heltec Wireless Tracker.