### PR TITLE
Added profilelabel - personal note which can be seen on display when changing beacon profile

### DIFF
--- a/data/tracker_conf.json
+++ b/data/tracker_conf.json
@@ -8,7 +8,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 0	
+			"smartBeaconSetting": 0,
+			"profilelabel": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -18,7 +19,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 2
+			"smartBeaconSetting": 2,
+			"profilelabel": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -28,7 +30,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 1
+			"smartBeaconSetting": 1,
+			"profilelabel": ""
 		}
 	],
 	"display": {

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -28,11 +28,11 @@
                                     Configuration
                                 </a>
                             </li>
-                            <li class="nav-item">
+                            <!-- <li class="nav-item">
                                 <a class="nav-link" href="/update">
                                     Update <small>OTA</small>
                                 </a>
-                            </li>
+                            </li> -->
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Backup</a>
                                 <div class="dropdown-menu">
@@ -80,7 +80,7 @@
                         <small>* - For now time is measured from board boot up.</small>
                     </div>
                 </div>
-                <hr />
+                <hr>
             </div>
         
             <div class="container" id="configuration">
@@ -110,7 +110,7 @@
                                 class="list-beacon col-9">
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -269,7 +269,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -384,7 +384,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -410,7 +410,7 @@
                                 class="list-lora col-9">
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -491,7 +491,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -538,7 +538,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -657,7 +657,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -936,7 +936,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -1067,7 +1067,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -1116,7 +1116,7 @@
                                 </div>
                             </div>                            
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -1165,7 +1165,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                     </div>
                 </main>

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -142,6 +142,15 @@ function loadSettings(settings) {
                     <option value="2" ${beacons.smartBeaconSetting == 2 ? 'selected' : ''}>Car/Motorcycle (Fast Speed)</option>
                 </select>
             </div>
+            <div class="form-floating col-12 col-md-9 px-1 mb-2" style="margin-left: 50px;">
+                <input 
+                    type="text" 
+                    class="form-control form-control-sm" 
+                    name="beacons.${index}.profilelabel" 
+                    id="beacons.${index}.profilelabel" 
+                    value="${beacons.profilelabel}">
+                <label for="beacons.${index}.profilelabel">Profile Label</label>
+            </div>
         `;
         beaconContainer.appendChild(beaconElement);
     });

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -119,7 +119,7 @@ bool Configuration::readFile() {
             bcn.smartBeaconSetting      = BeaconsArray[i]["smartBeaconSetting"] | 0;
             bcn.micE                    = BeaconsArray[i]["micE"] | "";
             bcn.gpsEcoMode              = BeaconsArray[i]["gpsEcoMode"] | false;
-            
+            bcn.profilelabel            = BeaconsArray[i]["profilelabel"] | "";
             beacons.push_back(bcn);
         }
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -26,6 +26,7 @@ void Configuration::writeFile() {
         data["beacons"][i]["smartBeaconSetting"]    = beacons[i].smartBeaconSetting;
         data["beacons"][i]["micE"]                  = beacons[i].micE;
         data["beacons"][i]["gpsEcoMode"]            = beacons[i].gpsEcoMode;
+        data["beacons"][i]["profilelabel"]          = beacons[i].profilelabel;
     }
 
     data["display"]["showSymbol"]               = display.showSymbol;
@@ -231,6 +232,7 @@ void Configuration::init() {
         beacon.smartBeaconSetting   = 0;
         beacon.micE                 = "";
         beacon.gpsEcoMode           = false;
+        beacon.profilelabel         = "";
         beacons.push_back(beacon);
     }
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -21,6 +21,7 @@ public:
     byte    smartBeaconSetting;
     String  micE;
     bool    gpsEcoMode;
+    String  profilelabel;
 };
 
 class Display {

--- a/src/keyboard_utils.cpp
+++ b/src/keyboard_utils.cpp
@@ -78,6 +78,7 @@ int         downCounter             = 0;
 int         leftCounter             = 0;
 int         rightCounter            = 0;
 int         trackBallSensitivity    = 5;
+String      profilelabel            = "";
 
 
 namespace KEYBOARD_Utils {
@@ -286,7 +287,13 @@ namespace KEYBOARD_Utils {
             statusState  = true;
             statusTime = millis();
             winlinkCommentState = false;
-            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "-----> " + Config.beacons[myBeaconsIndex].callsign, "", 2000);
+            if(strlen(Config.beacons[myBeaconsIndex].profilelabel.c_str()) >0 ){ //if length of the profilelabel is > 0 print the comment when changing callsign. Else don't.
+                profilelabel = " (" + Config.beacons[myBeaconsIndex].profilelabel + ")";
+            }
+            else{
+                profilelabel = "";
+            }
+            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "--> " + Config.beacons[myBeaconsIndex].callsign + profilelabel, "", 2000);
             STATION_Utils::saveIndex(0, myBeaconsIndex);
             sendStartTelemetry = true;
             if (menuDisplay == 200) menuDisplay = 20;

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -90,6 +90,7 @@ namespace WEB_Utils {
             Config.beacons[i].overlay               = request->getParam("beacons." + String(i) + ".overlay", true)->value();
             Config.beacons[i].micE                  = request->getParam("beacons." + String(i) + ".micE", true)->value();
             Config.beacons[i].comment               = request->getParam("beacons." + String(i) + ".comment", true)->value();
+            Config.beacons[i].profilelabel          = request->getParam("beacons." + String(i) + ".profilelabel", true)->value();
 
             String paramGpsEcoMode = "beacons." + String(i) + ".gpsEcoMode";
             if (request->hasParam(paramGpsEcoMode, true)) {


### PR DESCRIPTION
I have made new pull request with added config over web.

As mentioned idea behind profile label is that you can set up a personal profile label which can be seen only on the display when changing beacon configurations. 
Examples: 
If I'm using car icon I could set profile label as: car
If someone would decide to have two separate beacon profiles which are the same other that comment.
Profile label for first one could be: Comment1
Profile label for seconf one could be: Comment2

As mentioned I have also added Profile Labels into webconfig. I have tested this on my T-Beam Supreme.