### PR TITLE
Fixed a bug looking up smartBeaconSettings

### DIFF
--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -164,7 +164,7 @@ void loop() {
     }
     POWER_Utils::batteryManager();
 
-    SMARTBEACON_Utils::checkValues(myBeaconsIndex);
+    SMARTBEACON_Utils::checkValues(currentBeacon->smartBeaconSetting);
     SMARTBEACON_Utils::checkState();
 
     if (!Config.simplifiedTrackerMode) {


### PR DESCRIPTION
SMARTBEACON_Utils::checkValues was being passed myBeaconsIndex rather than currentBeacon->smartBeaconSetting

This meant it crashes if there are more than three beacon configs and the selected beacon was fourth or later because SMARTBEACON_Utils::checkInterval was giving nonsense values for currentSmartBeaconValues and then dividing by zero on line 43