### PR TITLE
Update boards_pinout.h add BUTTON_PIN for TTGO_T_LORA32_V2_1

### DIFF
--- a/src/boards_pinout.h
+++ b/src/boards_pinout.h
@@ -75,6 +75,7 @@
     #define RADIO_CS_PIN        18  // CS  --> NSS
     #define RADIO_RST_PIN       23
     #define RADIO_BUSY_PIN      26  // IRQ --> DIO0
+    #define BUTTON_PIN          23
 #endif
 
 


### PR DESCRIPTION
I'm using lora32 TNC, but there was no button available, my code providing possibility to use external button for TTGO_T_LORA32_V2_1  implementation connected to IO23.