### PR TITLE
Added profile label.

### DIFF
--- a/data/tracker_conf.json
+++ b/data/tracker_conf.json
@@ -8,7 +8,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 0	
+			"smartBeaconSetting": 0,
+			"profilelabel": ""	
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -18,7 +19,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 2
+			"smartBeaconSetting": 2,
+			"profilelabel": ""
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -28,7 +30,8 @@
 			"micE": "",
 			"comment": "",
 			"smartBeaconActive": true,
-			"smartBeaconSetting": 1
+			"smartBeaconSetting": 1,
+			"profilelabel": ""
 		}
 	],
 	"display": {

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -70,7 +70,7 @@
                         <small>* - For now time is measured from board boot up.</small>
                     </div>
                 </div>
-                <hr />
+                <hr>
             </div>
         
             <div class="container" id="configuration">
@@ -100,7 +100,7 @@
                                 class="list-beacon col-9">
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -275,7 +275,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -390,7 +390,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -416,7 +416,7 @@
                                 class="list-lora col-9">
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -497,7 +497,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -577,7 +577,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -696,7 +696,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -975,7 +975,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -1106,7 +1106,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -1155,7 +1155,7 @@
                                 </div>
                             </div>                            
                         </div>
-                        <hr />
+                        <hr>
 
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
@@ -1204,7 +1204,7 @@
                                 </div>
                             </div>
                         </div>
-                        <hr />
+                        <hr>
 
                     </div>
                 </main>

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -142,6 +142,15 @@ function loadSettings(settings) {
                     <option value="2" ${beacons.smartBeaconSetting == 2 ? 'selected' : ''}>Car/Motorcycle (Fast Speed)</option>
                 </select>
             </div>
+            <div class="form-floating col-12 col-md-9 px-1 mb-2" style="margin-left: 50px;">
+                <input 
+                    type="text" 
+                    class="form-control form-control-sm" 
+                    name="beacons.${index}.profilelabel" 
+                    id="beacons.${index}.profilelabel" 
+                    value="${beacons.profilelabel}">
+                <label for="beacons.${index}.profilelabel">Profile Label</label>
+            </div>
         `;
         beaconContainer.appendChild(beaconElement);
     });

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -21,6 +21,7 @@ public:
     byte    smartBeaconSetting;
     String  micE;
     bool    gpsEcoMode;
+    String  profilelabel;
 };
 
 class Display {

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -27,6 +27,7 @@ void Configuration::writeFile() {
         data["beacons"][i]["smartBeaconSetting"]    = beacons[i].smartBeaconSetting;
         data["beacons"][i]["micE"]                  = beacons[i].micE;
         data["beacons"][i]["gpsEcoMode"]            = beacons[i].gpsEcoMode;
+        data["beacons"][i]["profilelabel"]          = beacons[i].profilelabel;
     }
 
     data["display"]["showSymbol"]               = display.showSymbol;
@@ -129,7 +130,7 @@ bool Configuration::readFile() {
             bcn.smartBeaconSetting      = BeaconsArray[i]["smartBeaconSetting"] | 0;
             bcn.micE                    = BeaconsArray[i]["micE"] | "";
             bcn.gpsEcoMode              = BeaconsArray[i]["gpsEcoMode"] | false;
-            
+            bcn.profilelabel            = BeaconsArray[i]["profilelabel"] | "";
             beacons.push_back(bcn);
         }
 
@@ -250,6 +251,7 @@ void Configuration::init() {
         beacon.smartBeaconSetting   = 0;
         beacon.micE                 = "";
         beacon.gpsEcoMode           = false;
+        beacon.profilelabel         = "";
         beacons.push_back(beacon);
     }
 

--- a/src/keyboard_utils.cpp
+++ b/src/keyboard_utils.cpp
@@ -63,6 +63,7 @@ String      messageText             = "";
 int         messagesIterator        = 0;
 
 bool        showHumanHeading        = false;
+String      profilelabel            = "";
 
 
 namespace KEYBOARD_Utils {
@@ -287,7 +288,13 @@ namespace KEYBOARD_Utils {
             statusState  = true;
             statusTime = millis();
             winlinkCommentState = false;
-            displayShow("   INFO", "", "  CHANGING CALLSIGN!", "", "-----> " + Config.beacons[myBeaconsIndex].callsign, "", 2000);
+            if(strlen(Config.beacons[myBeaconsIndex].profilelabel.c_str()) >0 ){ //if length of the profilelabel is > 0 then print the comment when changing callsign. Else don't.
+                profilelabel = " (" + Config.beacons[myBeaconsIndex].profilelabel + ")";
+            }
+            else{
+                profilelabel = "";
+            }
+            displayShow("__ INFO __", "", "  CHANGING CALLSIGN!", "", "--> " + Config.beacons[myBeaconsIndex].callsign + profilelabel, "", 2000);
             STATION_Utils::saveIndex(0, myBeaconsIndex);
             sendStartTelemetry = true;
             if (menuDisplay == 200) menuDisplay = 20;

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -90,6 +90,7 @@ namespace WEB_Utils {
             Config.beacons[i].overlay               = request->getParam("beacons." + String(i) + ".overlay", true)->value();
             Config.beacons[i].micE                  = request->getParam("beacons." + String(i) + ".micE", true)->value();
             Config.beacons[i].comment               = request->getParam("beacons." + String(i) + ".comment", true)->value();
+            Config.beacons[i].profilelabel          = request->getParam("beacons." + String(i) + ".profilelabel", true)->value();
 
             String paramGpsEcoMode = "beacons." + String(i) + ".gpsEcoMode";
             if (request->hasParam(paramGpsEcoMode, true)) {


### PR DESCRIPTION
Added an option to add personal profile label which can be only seen on the screen during profile change and inside the web UI. 

Idea behind it is that you could name your profiles  in case you are using same icon but different smart beaconing settings, using APRS icon which is not correctly printed on the screen etc.