### PR TITLE
Increase batt voltage measurement accuracy on boards without AXP Battery Chip

### DIFF
--- a/include/power_utils.h
+++ b/include/power_utils.h
@@ -29,6 +29,8 @@
 
 namespace POWER_Utils {
 
+    void    batteryManager();
+    void    batteryManager_Init();
     double  getBatteryVoltage();
     const String getBatteryInfoVoltage();
     const String getBatteryInfoCurrent();
@@ -42,7 +44,11 @@ namespace POWER_Utils {
     double  getBatteryChargeDischargeCurrent();
     bool    isBatteryConnected();
     void    obtainBatteryInfo();
-    void    batteryManager();
+
+#ifdef ADC_CTRL
+    void adc_ctrl_on();
+    void adc_ctrl_off();
+#endif
 
     void    activateMeasurement();
 

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -197,12 +197,12 @@ void loop() {
 
     SMARTBEACON_Utils::checkSettings(currentBeacon->smartBeaconSetting);
     SMARTBEACON_Utils::checkState();
-
-    if (!Config.simplifiedTrackerMode) {
-        #ifdef BUTTON_PIN
+    
+    #ifdef BUTTON_PIN
+        if (!Config.simplifiedTrackerMode) {
             BUTTON_Utils::loop();
-        #endif
     }
+    #endif
 
     Utils::checkDisplayEcoMode();
 

--- a/src/power_utils.cpp
+++ b/src/power_utils.cpp
@@ -92,27 +92,29 @@ namespace POWER_Utils {
     }
 
     void batteryManager() {
-        #ifdef ADC_CTRL
+        #if BATTERY_PIN
             if ((millis() - batteryMeasurmentTime) > 30 * 1000){ //At least 30 seconds have to pass between measurements
-                switch(meas_State){
-                    case 0: //ADC_CTRL_ON State
-                        adc_ctrl_on();
-                        ADCCtrlTime = millis();
-                        meas_State = 1;
-                        break;
-                    case 1: // Measurement State
-                        if((millis() - ADCCtrlTime) > 50){ //At least 50ms have to pass after ADC_Ctrl Mosfet is turned on for voltage to stabilize
-                            obtainBatteryInfo();
-                            adc_ctrl_off();
-                            meas_State = 0;
-                        }
-                        break;
-                }
+                #ifdef ADC_CTRL
+                    switch(meas_State){
+                        case 0: //ADC_CTRL_ON State
+                            adc_ctrl_on();
+                            ADCCtrlTime = millis();
+                            meas_State = 1;
+                            break;
+                        case 1: // Measurement State
+                            if((millis() - ADCCtrlTime) > 50){ //At least 50ms have to pass after ADC_Ctrl Mosfet is turned on for voltage to stabilize
+                                obtainBatteryInfo();
+                                adc_ctrl_off();
+                                meas_State = 0;
+                            }
+                            break;
+                    }
+                #else
+                    obtainBatteryInfo();
+                #endif       
             }
-        #else
+        #else if defined(HAS_AXP192) || defined(HAS_AXP2101)
             obtainBatteryInfo();
-        #endif
-            #if defined(HAS_AXP192) || defined(HAS_AXP2101)
             handleChargingLed();
         #endif
     }


### PR DESCRIPTION
Modified according to: https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/peripherals/adc.html 

Official Espressif documentation suggests adding capacitor on the ADC input of the chip and doing average of multiple measurements.

Modified code does exactly that  by doing 20 measurements and greatly improves Batt voltage measurement.  Looking at the telemetry on aprs.fi it can be seen that voltage fluctuations are not there anymore. During normal operation voltage is jumping up to +-0.01V.
This also helps with unwanted LowVoltagePowerOff. It happened to me that HWT turned off because of LowVoltage measurement for which the limit was set at 2.9V. After turning it back on voltage was above 3.4V.

I have also tried soldering additional 100nF capacitor parallel to the lower resistor of voltage divider which improves this measurement even more, but just using averaging helps a lot.

Code has also been modified for a better readability (created additional functions for ADC_CTRL, moved functions which are responsible for voltage measurements closer together)