### PR TITLE
📨 Add APRS Message Writer and Sender / Añadido Guardado y Envío de Mensajes APRS

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -28,6 +28,11 @@
                                     Configuration
                                 </a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="#aprs-messages">
+                                    Write Messages
+                                </a>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Backup</a>
                                 <div class="dropdown-menu">
@@ -1210,7 +1215,34 @@
                             </div>
                         </div>
                         <hr>
+                        <div class="row my-4" id="aprs-messages">
+                            <div class="col-12">
+                                <h5>
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-envelope" viewBox="0 0 16 16">
+                                        <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v.217l-8 4.8-8-4.8V4z"/>
+                                        <path d="M0 6.383V12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6.383l-7.555 4.533a1 1 0 0 1-1.11 0L0 6.383z"/>
+                                    </svg>
+                                    Write Messages
+                                </h5>
 
+                                <div class="row mt-3">
+                                    <div class="col-md-5 col-sm-12 mb-2">
+                                        <label for="sms_destinatario" class="form-label">To: (callsign)</label>
+                                        <input type="text" class="form-control" id="sms_destinatario" name="sms.destinatario" placeholder="Ej: EA1ABC" maxlength="12" />
+                                    </div>
+
+                                    <div class="col-md-5 col-sm-12 mb-2">
+                                        <label for="sms_mensaje" class="form-label">Message (máx. 67 characters)</label>
+                                        <input type="text" class="form-control" id="sms_mensaje" name="sms.mensaje" placeholder="APRS message content" maxlength="67" />
+                                    </div>
+
+                                    <div class="col-md-2 col-sm-12 d-flex align-items-end mb-2">
+                                        <button type="button" id="save-sms-btn" class="btn btn-primary w-100">Save Message</button>
+                                    </div>
+                                </div>
+                                <hr>
+                            </div>
+                        </div>
                     </div>
                 </main>
                 <footer

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -477,5 +477,51 @@ form.addEventListener("submit", async (event) => {
     setTimeout(checkConnection, 2000);
 });
 
+const saveBtn = document.getElementById('save-sms-btn');
+
+saveBtn.addEventListener('click', async function () {
+    const toField = document.getElementById('sms_destinatario');
+    const msgField = document.getElementById('sms_mensaje');
+
+    const destination = toField.value.trim();
+    const messageText = msgField.value.trim();
+
+    if (!destination || !messageText) {
+        alert("Destination and message cannot be empty.");
+        return;
+    }
+
+    if (messageText.length > 67) {
+        alert("APRS message cannot exceed 67 characters.");
+        return;
+    }
+
+    const params = new URLSearchParams();
+    params.append("destination", destination);
+    params.append("message", messageText);
+
+    try {
+        const resp = await fetch('/saveMessageAPRS', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: params.toString()
+        });
+
+        if (!resp.ok) {
+            alert("Server error: " + resp.status);
+            return;
+        }
+
+        alert("Message to " + destination + " has been saved!. Click on 'Save Configuration' to reboot and disable AP mode'");
+        toField.value = "";
+        msgField.value = "";
+
+    } catch (err) {
+        alert("Network error: " + err.message);
+    }
+
+});
 
 fetchSettings();

--- a/include/msg_utils.h
+++ b/include/msg_utils.h
@@ -31,9 +31,11 @@ struct Packet15SegBuffer {
 namespace MSG_Utils {
 
     bool    warnNoAPRSMessages();
+    bool    warnNoSavedMessages();
     bool    warnNoWLNKMails();
     const String getLastHeardTracker();
     int     getNumAPRSMessages();
+    int     getNumSavedMessages();
     int     getNumWLNKMails();
     void    loadNumMessages();
     void    loadMessagesFromMemory(uint8_t typeOfMessage);
@@ -46,6 +48,7 @@ namespace MSG_Utils {
     void    clean15SegBuffer();
     bool    check15SegBuffer(const String& station, const String& textMessage);
     void    checkReceivedMessage(ReceivedLoRaPacket packetReceived);
+    bool    writeFileMessages(const String& destination, const String& textMessage);
 
 }
 

--- a/src/keyboard_utils.cpp
+++ b/src/keyboard_utils.cpp
@@ -68,6 +68,8 @@ extern bool             winlinkCommentState;
 extern bool             gpsIsActive;
 extern bool             sendStartTelemetry;
 extern uint8_t          keyboardAddress;
+extern String           msgTo;
+extern String           msgText;
 
 extern std::vector<String>  outputMessagesBuffer;
 
@@ -164,9 +166,9 @@ namespace KEYBOARD_Utils {
             menuDisplay++;
             if (menuDisplay > 6) menuDisplay = 1;
         }
-        else if (menuDisplay >= 10 && menuDisplay <= 13) {
+        else if (menuDisplay >= 10 && menuDisplay <= 14) {
             menuDisplay++;
-            if (menuDisplay > 13) menuDisplay = 10;
+            if (menuDisplay > 14) menuDisplay = 10;
         } else if (menuDisplay >= 130 && menuDisplay <= 133) {
             menuDisplay++;
             if (menuDisplay > 133) menuDisplay = 130;
@@ -181,7 +183,14 @@ namespace KEYBOARD_Utils {
             }
         } else if (menuDisplay == 110) {
             menuDisplay = 11;
-        }
+        } else if (menuDisplay == 140) {
+            messagesIterator++;
+            if (messagesIterator == MSG_Utils::getNumSavedMessages()) {
+                messagesIterator = 0;
+            } else {
+                menuDisplay = 140;
+            }
+        } 
         
         else if (menuDisplay >= 20 && menuDisplay <= 27) {
         menuDisplay++;
@@ -324,7 +333,7 @@ namespace KEYBOARD_Utils {
             STATION_Utils::saveIndex(0, myBeaconsIndex);
             sendStartTelemetry = true;
             if (menuDisplay == 200) menuDisplay = 20;
-        } else if ((menuDisplay >= 1 && menuDisplay <= 6) || (menuDisplay >= 11 &&menuDisplay <= 13) || (menuDisplay >= 20 && menuDisplay <= 27) || (menuDisplay >= 40 && menuDisplay <= 41)) {
+        } else if ((menuDisplay >= 1 && menuDisplay <= 6) || (menuDisplay >= 11 &&menuDisplay <= 14) || (menuDisplay >= 20 && menuDisplay <= 27) || (menuDisplay >= 40 && menuDisplay <= 41)) {
             menuDisplay = menuDisplay * 10;
         } else if (menuDisplay == 10) {
             MSG_Utils::loadMessagesFromMemory(0);
@@ -355,6 +364,23 @@ namespace KEYBOARD_Utils {
         } else if (menuDisplay == 132 || menuDisplay == 133) {
             displayShow(" APRS Thu.", "", (menuDisplay == 132) ? "   Unsubscribe" : "  Keep Subscribed", (menuDisplay == 132) ? "   from APRS Thursday" : "  for 12hours more", "", "", 2000);
             MSG_Utils::addToOutputBuffer(0, "ANSRVR", (menuDisplay == 132) ? "U HOTG" : "K HOTG");
+            #ifdef HAS_JOYSTICK
+                menuDisplay = 13;
+            #endif
+        } else if (menuDisplay == 14) {
+            MSG_Utils::loadMessagesFromMemory(2);
+            if (MSG_Utils::warnNoSavedMessages()) {
+                #ifdef HAS_JOYSTICK
+                    menuDisplay = 11;
+                #else
+                    menuDisplay = 14;
+                #endif
+            } else {
+                menuDisplay = 140;
+            }
+        } else if (menuDisplay == 140) {
+            MSG_Utils::addToOutputBuffer(0, msgTo, msgText);
+            menuDisplay = 14;
             #ifdef HAS_JOYSTICK
                 menuDisplay = 13;
             #endif

--- a/src/menu_utils.cpp
+++ b/src/menu_utils.cpp
@@ -39,6 +39,7 @@ extern Beacon               *currentBeacon;
 extern Configuration        Config;
 extern TinyGPSPlus          gps;
 extern std::vector<String>  loadedAPRSMessages;
+extern std::vector<String>  loadedSavedMessages;
 extern std::vector<String>  loadedWLNKMails;
 extern int                  messagesIterator;
 extern uint8_t              loraIndex;
@@ -73,6 +74,8 @@ extern bool                 gpsIsActive;
 
 String      freqChangeWarning;
 uint8_t     lowBatteryPercent       = 21;
+String      msgTo;
+String      msgText;
 
 #if defined(TTGO_T_DECK_PLUS) || defined(TTGO_T_DECK_GPS)
     String topHeader1   = "";
@@ -201,7 +204,7 @@ namespace MENU_Utils {
                 }
                 break;
             case 11:    // 1.Messages ---> Messages Write
-                displayShow(" MESSAGES>", "  Read (" + String(MSG_Utils::getNumAPRSMessages()) + ")", "> Write", "  Delete", "  APRSThursday", lastLine);
+                displayShow(" MESSAGES>", "> Write", "  Delete", "  APRSThursday", "  Saved Messages" , lastLine);
                 break;
             case 110:   // 1.Messages ---> Messages Write ---> Write
                 if (keyDetected || keyboardConnected) {
@@ -254,13 +257,13 @@ namespace MENU_Utils {
                 }
                 break;
             case 12:    // 1.Messages ---> Messages Delete
-                displayShow(" MESSAGES>", "  Read (" + String(MSG_Utils::getNumAPRSMessages()) + ")", "  Write", "> Delete", "  APRSThursday", lastLine);
+                displayShow(" MESSAGES>", "> Delete", "  APRSThursday", "  Saved Messages", "  Read (" + String(MSG_Utils::getNumAPRSMessages()) + ")", lastLine);
                 break;
             case 120:   // 1.Messages ---> Messages Delete ---> Delete: ALL
                 displayShow("DELETE MSG", "", "  DELETE APRS MSG?", "", "", " Confirm = LP or '>'");
                 break;
             case 13:    // 1.Messages ---> APRSThursday
-                displayShow(" MESSAGES>", "  Read (" + String(MSG_Utils::getNumAPRSMessages()) + ")", "  Write", "  Delete", "> APRSThursday", lastLine);
+                displayShow(" MESSAGES>", "> APRSThursday", "  Saved Messages", "  Read (" + String(MSG_Utils::getNumAPRSMessages()) + ")", "  Write", lastLine);
                 break;
             case 130:   // 1.Messages ---> APRSThursday ---> Delete: ALL
                 displayShow(" APRS Thu.", "> Check In", "  Join", "  Unsubscribe", "  KeepSubscribed+12h", lastLine);
@@ -344,7 +347,29 @@ namespace MENU_Utils {
             case 133:   // 1.Messages ---> APRSThursday ---> Delete: ALL
                 displayShow(" APRS Thu.", "  Check In", "  Join", "  Unsubscribe", "> KeepSubscribed+12h", lastLine);
                 break;
+            case 14:   // 1.Messages ---> Saved Messages
+                displayShow(" MESSAGES>", "> Saved Messages", "  Read (" + String(MSG_Utils::getNumAPRSMessages()) + ")", "  Write", "  Delete", lastLine);
+                break;
+            case 140:   // 1.Messages ---> Saved Messages ---> Send Message saved
+                {
+                    MSG_Utils::loadMessagesFromMemory(2);
 
+                    msgTo    = loadedSavedMessages[messagesIterator].substring(0, loadedSavedMessages[messagesIterator].indexOf(","));
+                    msgText  = loadedSavedMessages[messagesIterator].substring(loadedSavedMessages[messagesIterator].indexOf(",") + 1);
+
+                    if (msgText.length() > 40) msgText = msgText.substring(0, 50) + "...";
+
+                    #ifdef HAS_TFT
+                        #if defined(HELTEC_WIRELESS_TRACKER)
+                            displayShow("SENT MSG>", "From --> " + msgSender, msgText,"                 Next=Down", "", "");
+                        #else   // T-Deck
+                            displayShow("SENT MSG>", "From --> " + msgSender, msgText,"             Next=Down", "", "");
+                        #endif
+                    #else
+                        displayShow("SEND MSG>", "To:" + msgTo, msgText, "", "", "1P=Next 2P=Back LP=Send");
+                    #endif
+                }
+                break;
 //////////
             case 20:    // 2.Configuration ---> Callsign
                 displayShow(" CONFIG>", "  Power Off", "> Change Callsign ", "  Change Frequency", "  Display",lastLine);

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -18,9 +18,13 @@
 
 #include <ArduinoJson.h>
 #include "configuration.h"
+#include "msg_utils.h"
 #include "web_utils.h"
 #include "display.h"
 #include "utils.h"
+#include "logger.h"
+
+extern logging::Logger      logger;
 
 extern Configuration               Config;
 
@@ -313,6 +317,40 @@ namespace WEB_Utils {
         request->send(response);
     }
 
+    void handleSaveMessageAPRS(AsyncWebServerRequest *request) {
+        if (request->method() != HTTP_POST) {
+            request->send(405, "text/plain", "Method Not Allowed");
+            return;
+        }
+
+        String destination = request->hasParam("destination", true) ? request->getParam("destination", true)->value() : "";
+        String messageText = request->hasParam("message", true) ? request->getParam("message", true)->value() : "";
+
+        if (destination.length() == 0 || messageText.length() == 0) {
+            request->send(400, "text/plain", "Destination or message is empty");
+            return;
+        }
+
+       bool saveSuccess = MSG_Utils::writeFileMessages(destination, messageText);
+
+        if (saveSuccess) {
+            Serial.println("Message saved successfully");
+            request->send(200, "text/plain", "Message saved successfully");
+            
+            logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "Main", "Number of APRS Messages : %s",messageText);
+
+        } else {
+            Serial.println("Error saving messages!");
+            String errorPage = "<!DOCTYPE html><html><head><title>Error</title></head><body>";
+            errorPage += "<h1>Message Error:</h1>";
+            errorPage += "<p>Couldn't save new message. Please try again.</p>";
+            errorPage += "<a href='/'>Back</a></body></html>";
+            
+            AsyncWebServerResponse *response = request->beginResponse(500, "text/html", errorPage);
+            request->send(response);
+        }
+    }
+
     void setup() {
         server.on("/", HTTP_GET, handleHome);
         server.on("/status", HTTP_GET, handleStatus);
@@ -325,6 +363,7 @@ namespace WEB_Utils {
         server.on("/bootstrap.css", HTTP_GET, handleBootstrapStyle);
         server.on("/bootstrap.js", HTTP_GET, handleBootstrapScript);
         server.on("/favicon.png", HTTP_GET, handleFavicon);
+        server.on("/saveMessageAPRS", HTTP_POST, handleSaveMessageAPRS);
 
         server.onNotFound(handleNotFound);
 


### PR DESCRIPTION
**English**

This PR introduces a new feature that allows users to write and send APRS messages directly from a web-based form, without the need for a physical keyboard.
The implementation includes server-side handling to store messages in a text file if desired (/savedMessages.txt), enabling later use from the device menu.

This functionality has been successfully tested on the LILYGO T-BEAM, and it is designed to facilitate sending APRS spots for SOTA activations more easily and quickly using only the web interface.

---
**Español**

Este PR incorpora una nueva funcionalidad que permite escribir y enviar mensajes APRS directamente desde un formulario web, sin necesidad de disponer de un teclado físico.
La implementación incluye la lógica en el servidor para guardar los mensajes en un archivo de texto si se desea (/savedMessages.txt), permitiendo su uso posterior desde el menú del dispositivo.

Esta característica ha sido probada con éxito en la LILYGO T-BEAM, y está pensada para facilitar la publicación de spots SOTA de forma más simple y rápida usando únicamente la interfaz web.