### PR TITLE
Fix T-Deck Plus PSRAM and I2S speaker boot crash

### DIFF
--- a/src/power_utils.cpp
+++ b/src/power_utils.cpp
@@ -225,14 +225,21 @@ namespace POWER_Utils {
     }
 
     void externalPinSetup() {
-        if (Config.notification.buzzerActive && Config.notification.buzzerPinTone >= 0 && Config.notification.buzzerPinVcc >= 0) {
-            pinMode(Config.notification.buzzerPinTone, OUTPUT);
-            pinMode(Config.notification.buzzerPinVcc, OUTPUT);
-            if (Config.notification.bootUpBeep) NOTIFICATION_Utils::start();
-        } else if (Config.notification.buzzerActive && (Config.notification.buzzerPinTone < 0 || Config.notification.buzzerPinVcc < 0)) {
-            logger.log(logging::LoggerLevel::LOGGER_LEVEL_WARN, "PINOUT", "Buzzer Pins not defined");
-            while (1);
-        }
+        #ifdef HAS_I2S
+            // T-Deck Plus uses I2S speaker, no GPIO buzzer pins needed
+            if (Config.notification.buzzerActive && Config.notification.bootUpBeep) {
+                NOTIFICATION_Utils::start();
+            }
+        #else
+            if (Config.notification.buzzerActive && Config.notification.buzzerPinTone >= 0 && Config.notification.buzzerPinVcc >= 0) {
+                pinMode(Config.notification.buzzerPinTone, OUTPUT);
+                pinMode(Config.notification.buzzerPinVcc, OUTPUT);
+                if (Config.notification.bootUpBeep) NOTIFICATION_Utils::start();
+            } else if (Config.notification.buzzerActive && (Config.notification.buzzerPinTone < 0 || Config.notification.buzzerPinVcc < 0)) {
+                logger.log(logging::LoggerLevel::LOGGER_LEVEL_WARN, "PINOUT", "Buzzer Pins not defined");
+                while (1);
+            }
+        #endif
 
         if (Config.notification.ledTx && Config.notification.ledTxPin >= 0) {
             pinMode(Config.notification.ledTxPin, OUTPUT);

--- a/variants/ttgo_t_deck_plus/platformio.ini
+++ b/variants/ttgo_t_deck_plus/platformio.ini
@@ -5,6 +5,7 @@ board_build.partitions = huge_app.csv
 monitor_filters = esp32_exception_decoder
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
+board_build.arduino.memory_type = qio_opi
 board_build.embed_files = 
 	data_embed/index.html.gz
 	data_embed/style.css.gz
@@ -20,6 +21,7 @@ build_flags =
 	${common.usb_flags}
 	-D TTGO_T_DECK_PLUS
 	-D BOARD_HAS_PSRAM
+	-mfix-esp32-psram-cache-issue
 	-D USER_SETUP_LOADED
 	-D ST7789_DRIVER
 	-D TFT_WIDTH=240


### PR DESCRIPTION
## Summary
- Fix PSRAM configuration for T-Deck Plus (ESP32-S3FN16R8)
- Fix boot crash when using I2S speaker

## Changes

### PSRAM Configuration (platformio.ini)
- Add `board_build.arduino.memory_type = qio_opi` for correct Quad Flash + Octal PSRAM configuration
- Add `-mfix-esp32-psram-cache-issue` flag for PSRAM stability

### I2S Speaker (power_utils.cpp)
- Add `#ifdef HAS_I2S` conditional to skip GPIO buzzer pin setup
- T-Deck Plus uses I2S speaker (pins 5, 6, 7), not GPIO buzzer pins
- Prevents crash from attempting to configure invalid GPIO pins

## Test plan
- [x] Tested on T-Deck Plus with I2S speaker
- [x] Boot completes without crash
- [x] Startup sound plays correctly via I2S

🤖 Generated with [Claude Code](https://claude.com/claude-code)