### PR TITLE
Fix display ecoMode not being saved from web config

### DIFF
--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -176,7 +176,7 @@ namespace WEB_Utils {
         Config.simplifiedTrackerMode            = request->hasParam("simplifiedTrackerMode", true);
 
         //  Display
-        Config.display.ecoMode                  = request->hasParam("display.alwaysOn", true);
+        Config.display.ecoMode                  = request->hasParam("display.ecoMode", true);
         if (!Config.display.ecoMode) {
             Config.display.timeout              = getParamIntSafe("display.timeout", Config.display.timeout);
         }


### PR DESCRIPTION
## Summary
- Fixed web config not saving the display ecoMode setting
- The form parameter was incorrectly named `display.alwaysOn` instead of `display.ecoMode`

## Test plan
- [ ] Open web configuration interface
- [ ] Toggle the "ECO Mode" checkbox in Display settings
- [ ] Save configuration
- [ ] Verify the setting persists after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)