### PR TITLE
fix(battery): replace linear formula with Li-Ion discharge curve LUT

### DIFF
--- a/include/battery_utils.h
+++ b/include/battery_utils.h
@@ -23,6 +23,7 @@
 
 namespace BATTERY_Utils {
 
+    int     voltageToPercent(float voltage);
     String  getPercentVoltageBattery(float voltage);
     String  getBatteryInfoVoltage();
     float   readBatteryVoltage();


### PR DESCRIPTION
## Summary

- Replace linear battery percentage formula with a 21-point Li-Ion discharge curve lookup table
- Add `voltageToPercent()` function with linear interpolation between LUT points
- The old linear mapping `((voltage - 3.0) / 1.2) * 100` significantly overestimates remaining capacity in the 3.3V–3.7V range where Li-Ion cells discharge fastest
- Real-world testing showed ~67% displayed when the device was actually near depletion (screen flickering, backlight failing)

## Details

| Voltage | Old (linear) | New (Li-Ion LUT) |
|---------|-------------|-------------------|
| 4.2V    | 100%        | 100%              |
| 3.9V    | 75%         | 70%               |
| 3.7V    | 58%         | 50%               |
| 3.5V    | 42%         | 30%               |
| 3.3V    | 25%         | 10%               |

## Test plan

- [ ] Verify percentage reads lower than before at same voltage
- [ ] Verify 100% at full charge (4.2V)
- [ ] Verify 0% near cutoff (3.0V)
- [ ] Monitor discharge over time for realistic curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)