### PR TITLE
Add ttgo-t-beam-v1_SX1262 variant (AXP192 + SX1262) (900MHz).  

### DIFF
--- a/variants/ttgo-t-beam-v1_SX1262/board_pinout.h
+++ b/variants/ttgo-t-beam-v1_SX1262/board_pinout.h
@@ -1,0 +1,53 @@
+/* Copyright (C) 2025 Ricardo Guzman - CA2RXU
+ * 
+ * This file is part of LoRa APRS Tracker.
+ * 
+ * LoRa APRS Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or 
+ * (at your option) any later version.
+ * 
+ * LoRa APRS Tracker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with LoRa APRS Tracker. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BOARD_PINOUT_H_
+#define BOARD_PINOUT_H_
+
+    //  LoRa Radio
+    #define HAS_SX1262
+    #define RADIO_SCLK_PIN      5
+    #define RADIO_MISO_PIN      19
+    #define RADIO_MOSI_PIN      27
+    #define RADIO_CS_PIN        18
+    #define RADIO_DIO0_PIN      26
+    #define RADIO_RST_PIN       23
+    #define RADIO_DIO1_PIN      33
+    #define RADIO_BUSY_PIN      32
+
+    //  Display
+    #undef  OLED_SDA
+    #undef  OLED_SCL
+    #undef  OLED_RST
+
+    #define OLED_SDA            21
+    #define OLED_SCL            22
+    #define OLED_RST            16
+
+    //  GPS
+    #define HAS_GPS_CTRL
+    #define GPS_RX              12
+    #define GPS_TX              34
+
+    //  OTHER
+    #define BUTTON_PIN          38  // The middle button GPIO on the T-Beam
+
+    #define HAS_AXP192
+    #define HAS_BT_CLASSIC
+
+#endif

--- a/variants/ttgo-t-beam-v1_SX1262/platformio.ini
+++ b/variants/ttgo-t-beam-v1_SX1262/platformio.ini
@@ -1,0 +1,14 @@
+[env:ttgo-t-beam-v1_SX1262]
+extends = env:esp32
+board = ttgo-t-beam
+build_flags =
+	${common.build_flags}
+	-D RADIOLIB_EXCLUDE_LR11X0=1
+	-D RADIOLIB_EXCLUDE_SX127X=1
+	-D RADIOLIB_EXCLUDE_SX128X=1
+	-D TTGO_T_Beam_V1_0_SX1262
+lib_deps =
+	${common.lib_deps}
+	${common.display_libs}
+	lewisxhe/XPowersLib @ 0.2.4
+	adafruit/Adafruit SH110X @ 2.1.10


### PR DESCRIPTION
Closes richonguzman/LoRa_APRS_Tracker#254

Adds support for TTGO T-Beam V1 boardswith an SX1262 radio module (AXP192 + SX1262 combination), as discussed in #254. This hardware variant exists in the wild but was previously unsupported — the repo had AXP192+SX1268 and AXP2101+SX1262 but not AXP192+SX1262. My boards are marked T22_V1.1 20210222, see photo in https://github.com/richonguzman/LoRa_APRS_Tracker/issues/254

Changes:

New variant folder variants/ttgo-t-beam-v1_SX1262/ with platformio.ini and board_pinout.h
Pin assignments match the existing ttgo-t-beam-v1_SX1268 variant; HAS_SX1262 set accordingly, HAS_AXP192 for power management
Tested: builds clean, boots correctly, LoRa TX confirmed on target 900MHz frequency.

Note: I'm a hardware person learning my way through firmware. This PR was developed with AI assistance (Claude). The logic follows directly from the existing SX1268 variant pattern, so I'm confident in the approach, but I wanted to be transparent. 