### PR TITLE
Geofencing (dl2rxe)

### DIFF
--- a/data/tracker_conf.json
+++ b/data/tracker_conf.json
@@ -10,7 +10,11 @@
 			"status": "",
 			"smartBeaconActive": true,
 			"smartBeaconSetting": 0,
-			"profileLabel": ""
+			"profileLabel": "",
+			"geofence_latitude": 50.000,
+    		"geofence_longitude": 10.000,
+    		"geofence_radius": 1000,
+    		"geofence_mode": "inactive"
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -22,7 +26,11 @@
 			"status": "",
 			"smartBeaconActive": true,
 			"smartBeaconSetting": 2,
-			"profileLabel": ""
+			"profileLabel": "",
+			"geofence_latitude": 50.000,
+    		"geofence_longitude": 10.000,
+    		"geofence_radius": 1000,
+    		"geofence_mode": "pause"
 		},
 		{
 			"callsign": "NOCALL-7",
@@ -34,7 +42,11 @@
 			"status": "",
 			"smartBeaconActive": true,
 			"smartBeaconSetting": 1,
-			"profileLabel": ""
+			"profileLabel": "",
+			"geofence_latitude": 50.000,
+    		"geofence_longitude": 10.000,
+    		"geofence_radius": 1000,
+    		"geofence_mode": "poweroff"
 		}
 	],
 	"display": {

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -42,6 +42,10 @@ public:
     bool    gpsEcoMode;
     String  profileLabel;
     String  status;
+    double  geofence_latitude = 0.0;
+    double  geofence_longitude = 0.0;
+    int     geofence_radius = 0 ;
+    String  geofence_mode = "inactive";
 };
 
 class Display {

--- a/include/geofence.h
+++ b/include/geofence.h
@@ -1,0 +1,17 @@
+#ifndef GEOFENCE_H
+#define GEOFENCE_H
+#include <Arduino.h>
+#include <TinyGPS++.h>
+#include "configuration.h"
+
+extern bool geofence_pause;
+
+enum GeofenceMode {
+    GEOFENCE_INACTIVE = 0,      // Mode: inactive (normal operation)
+    GEOFENCE_PAUSE = 1,         // Mode: pause (no transmission)
+    GEOFENCE_POWEROFF = 2       // Mode: power off
+};
+
+void applyGeofence(TinyGPSPlus &gps, Beacon* currentBeacon);
+
+#endif

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -54,6 +54,10 @@ bool Configuration::writeFile() {
             data["beacons"][i]["gpsEcoMode"]            = beacons[i].gpsEcoMode;
             data["beacons"][i]["profileLabel"]          = beacons[i].profileLabel;
             data["beacons"][i]["status"]                = beacons[i].status;
+            data["beacons"][i]["geofence_latitude"]     = beacons[i].geofence_latitude;
+            data["beacons"][i]["geofence_longitude"]    = beacons[i].geofence_longitude;
+            data["beacons"][i]["geofence_radius"]       = beacons[i].geofence_radius;
+            data["beacons"][i]["geofence_mode"]         = beacons[i].geofence_mode;
         }
 
         data["display"]["ecoMode"]                  = display.ecoMode;
@@ -165,6 +169,10 @@ bool Configuration::readFile() {
             bcn.smartBeaconSetting      = BeaconsArray[i]["smartBeaconSetting"] | 0;
             bcn.gpsEcoMode              = BeaconsArray[i]["gpsEcoMode"] | false;
             bcn.profileLabel            = BeaconsArray[i]["profileLabel"] | "";
+            bcn.geofence_latitude       = BeaconsArray[i]["geofence_latitude"] | 0.0;
+            bcn.geofence_longitude      = BeaconsArray[i]["geofence_longitude"] | 0.0;
+            bcn.geofence_radius         = BeaconsArray[i]["geofence_radius"] | 0;
+            bcn.geofence_mode           = BeaconsArray[i]["geofence_mode"] | "inactive";
             beacons.push_back(bcn);
         }
 

--- a/src/geofence.cpp
+++ b/src/geofence.cpp
@@ -27,7 +27,7 @@ void applyGeofence(TinyGPSPlus &gps, Beacon* currentBeacon) {
 
         if (currentBeacon->geofence_mode == "pause") {
             geofence_pause = true;
-            displayShow("GEOFENCE", "", "TX pausing", 100);
+            displayShow("GEOFENCE","", "TX pausing","Radius: " + String(double(currentBeacon->geofence_radius),0)+" m","Distance: " + String(distance,0) + " m","", 100);
             delay(2000);
             return;
         }

--- a/src/geofence.cpp
+++ b/src/geofence.cpp
@@ -1,0 +1,47 @@
+#include "geofence.h"
+//#include <TinyGPS++.h>
+#include "display.h"
+#include "power_utils.h"
+
+bool geofence_pause = false;
+
+void applyGeofence(TinyGPSPlus &gps, Beacon* currentBeacon) {
+    if (!gps.location.isValid()) {
+        return;
+    }
+
+    // calculate distance
+    double distance = TinyGPSPlus::distanceBetween(
+        gps.location.lat(), 
+        gps.location.lng(), 
+        currentBeacon->geofence_latitude, 
+        currentBeacon->geofence_longitude
+    );
+
+    if (distance < (double)currentBeacon->geofence_radius) {
+        
+        if (currentBeacon->geofence_mode == "inactive") {
+            geofence_pause = false;
+            return;
+        }
+
+        if (currentBeacon->geofence_mode == "pause") {
+            geofence_pause = true;
+            displayShow("GEOFENCE", "", "TX pausing", 100);
+            delay(2000);
+            return;
+        }
+
+        if (currentBeacon->geofence_mode == "poweroff") {
+            geofence_pause = true;
+            displayShow("GEOFENCE", "", "powering off", 100);
+            delay(2000);
+            POWER_Utils::shutdown();
+        }
+    }
+    else
+    {
+           geofence_pause = false;
+     }
+    return;
+}

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -24,6 +24,7 @@
 #include "board_pinout.h"
 #include "lora_utils.h"
 #include "display.h"
+#include "geofence.h"
 
 extern logging::Logger  logger;
 extern Configuration    Config;
@@ -196,6 +197,7 @@ namespace LoRa_Utils {
             logger.log(logging::LoggerLevel::LOGGER_LEVEL_WARN, "LoRa Tx", "TX blocked by geofence");
             transmitFlag = true;
         return;
+        }
                     
         if (Config.ptt.active) {
             digitalWrite(Config.ptt.io_pin, Config.ptt.reverse ? LOW : HIGH);

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -187,11 +187,16 @@ namespace LoRa_Utils {
     }
 
     void sendNewPacket(const String& newPacket) {
-        logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa Tx","---> %s", newPacket.c_str());
+        logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "LoRa Tx","---> %s | geofence_pause=%s", newPacket.c_str(), geofence_pause ? "TRUE" : "FALSE");
         /*logger.log(logging::LoggerLevel::LOGGER_LEVEL_WARN, "LoRa","Send data: %s", newPacket.c_str());
         logger.log(logging::LoggerLevel::LOGGER_LEVEL_ERROR, "LoRa","Send data: %s", newPacket.c_str());
         logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, "LoRa","Send data: %s", newPacket.c_str());*/
 
+        if (geofence_pause) {
+            logger.log(logging::LoggerLevel::LOGGER_LEVEL_WARN, "LoRa Tx", "TX blocked by geofence");
+            transmitFlag = true;
+        return;
+                    
         if (Config.ptt.active) {
             digitalWrite(Config.ptt.io_pin, Config.ptt.reverse ? LOW : HIGH);
             delay(Config.ptt.preDelay);

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -31,6 +31,7 @@
 #include "wx_utils.h"
 #include "display.h"
 #include "logger.h"
+#include "geofence.h"
 
 extern Configuration        Config;
 extern Beacon               *currentBeacon;
@@ -249,6 +250,8 @@ namespace STATION_Utils {
         } else {
             packet += "**LowVoltagePowerOff**";
         }
+
+        applyGeofence(gps, currentBeacon);
 
         displayShow("<<< TX >>>", "", packet, 100);
         LoRa_Utils::sendNewPacket(packet);

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -252,8 +252,10 @@ namespace STATION_Utils {
         }
 
         applyGeofence(gps, currentBeacon);
-
-        displayShow("<<< TX >>>", "", packet, 100);
+        if (!geofence_pause)
+            {
+                displayShow("<<< TX >>>", "", packet, 100);
+            }
         LoRa_Utils::sendNewPacket(packet);
 
         if (Config.bluetooth.useBLE) BLE_Utils::sendToPhone(packet);   // send Tx packets to Phone too


### PR DESCRIPTION
Hi Ricardo,

Based on your excellent tracker software, I’ve added a geofencing feature that deactivates the tracker, pauses transmission or switches it off when it’s within a defined area. I need this feature so that I don’t constantly transmit my location (even during experiments) when I’m at home anyway.
Unfortunately, I’m no programming expert and have only tried it out with a TTGO T-Beam 1.2.
If you like, you’re welcome to reuse the code or the idea. Please forgive me if I’ve done something wrong here; this is my first attempt with GitHub and the like.

For the configuration in tracker_conf.json

Definition of the circle:
geofence_latitude = 50.0; // 50.000
geofence_longitude = 10.0; // 10.000
geofence_radius = 1000 ; / 1000 m
geofence_mode = ‘inactive’;

Possible modes:
inactive: normal tracker operation
pause: if the tracker is within the circle, it does not transmit
poweroff: if the tracker is within the circle, it switches off. (Tested with TTGO v1.2). This mode can only be exited if the GPS signal is invalid or the tracker is outside the circle.

Kind regards, Micha, DL2RXE, near Berlin, Germany
