### PR TITLE
Fix GPS baud rate definition in board_pinout.h

### DIFF
--- a/variants/ttgo-t-beam-v1_2_SX1262/board_pinout.h
+++ b/variants/ttgo-t-beam-v1_2_SX1262/board_pinout.h
@@ -43,7 +43,7 @@
     #define HAS_GPS_CTRL
     #define GPS_RX              12
     #define GPS_TX              34
-    #define GPS_BAUDRATE        115200
+    // #define GPS_BAUDRATE        115200  //wrong gps baudrate definition (see issue #307)
 
     //  OTHER
     #define BUTTON_PIN          38 // The middle button GPIO on the T-Beam


### PR DESCRIPTION
Commenting out this definition solved issue #307 GPS problem on T-Beam V1.2 with V2.3 firmware