### PR TITLE
T beam 1w fan battery

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -145,6 +145,7 @@ public:
 
     void setDefaultValues();
     bool writeFile();
+    bool begin();
     Configuration();
 
 private:

--- a/include/power_utils.h
+++ b/include/power_utils.h
@@ -51,6 +51,9 @@ namespace POWER_Utils {
 
     void externalPinSetup();
 
+    void handleFan();
+    void forceFanOn(uint32_t holdTimeMs = 60000);
+
     bool begin(TwoWire &port);
     void setup();
 

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -79,24 +79,24 @@ TinyGPSPlus                         gps;
 #endif
 
 uint8_t     myBeaconsIndex          = 0;
-int         myBeaconsSize           = Config.beacons.size();
-Beacon      *currentBeacon          = &Config.beacons[myBeaconsIndex];
+int         myBeaconsSize           = 0;
+Beacon      *currentBeacon          = nullptr;
 uint8_t     loraIndex               = 0;
-int         loraIndexSize           = Config.loraTypes.size();
-LoraType    *currentLoRaType        = &Config.loraTypes[loraIndex];
+int         loraIndexSize           = 0;
+LoraType    *currentLoRaType        = nullptr;
 
 int         menuDisplay             = 100;
 uint32_t    menuTime                = millis();
 
 bool        statusUpdate            = true;
-bool        displayEcoMode          = Config.display.ecoMode;
+bool        displayEcoMode          = false;
 bool        displayState            = true;
 uint32_t    displayTime             = millis();
 uint32_t    refreshDisplayTime      = millis();
 
 bool        sendUpdate              = true;
 
-bool        bluetoothActive         = Config.bluetooth.active;
+bool        bluetoothActive         = false;
 bool        bluetoothConnected      = false;
 
 uint32_t    lastTx                  = 0.0;
@@ -129,6 +129,14 @@ void setup() {
     #ifndef DEBUG
         logger.setDebugLevel(logging::LoggerLevel::LOGGER_LEVEL_INFO);
     #endif
+
+    Config.begin();
+    myBeaconsSize       = Config.beacons.size();
+    currentBeacon       = &Config.beacons[myBeaconsIndex];
+    loraIndexSize       = Config.loraTypes.size();
+    currentLoRaType     = &Config.loraTypes[loraIndex];
+    displayEcoMode      = Config.display.ecoMode;
+    bluetoothActive     = Config.bluetooth.active;
 
     POWER_Utils::setup();
     displaySetup();

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -197,6 +197,7 @@ void loop() {
     SMARTBEACON_Utils::checkState();
 
     BATTERY_Utils::monitor();
+    POWER_Utils::handleFan();
     Utils::checkDisplayEcoMode();
 
     #ifdef BUTTON_PIN

--- a/src/battery_utils.cpp
+++ b/src/battery_utils.cpp
@@ -51,8 +51,20 @@ float       lora32BatReadingCorr    = 6.5; // % of correction to higher value to
 namespace BATTERY_Utils {
 
     String getPercentVoltageBattery(float voltage) {
-        int percent = ((voltage - 3.0) / (4.2 - 3.0)) * 100;
-        return (percent < 100) ? (((percent < 10) ? "  ": " ") + String(percent)) : "100";
+        #if defined(TTGO_T_BEAM_1W)
+            const float emptyVoltage = 6.0;
+            const float fullVoltage = 8.4;
+        #else
+            const float emptyVoltage = 3.0;
+            const float fullVoltage = 4.2;
+        #endif
+
+        int percent = ((voltage - emptyVoltage) / (fullVoltage - emptyVoltage)) * 100;
+        percent = constrain(percent, 0, 100);
+
+        if (percent < 10) return "  " + String(percent);
+        if (percent < 100) return " " + String(percent);
+        return "100";
     }
 
     String getBatteryInfoVoltage() {
@@ -83,7 +95,7 @@ namespace BATTERY_Utils {
                 #endif
                 #if defined(TTGO_T_BEAM_1W)
                     double inputDivider = (1.0 / (300.0 + 150.0)) * 150.0;  // The voltage divider is a 300k + 150k resistor in series, 150k on the low side.
-                    return (voltage / inputDivider) + 0.285; // Yes, this offset is excessive, but the ADC on the ESP32s3 is quite inaccurate and noisy. Adjust to own measurements.
+                    return voltage / inputDivider;
                 #endif
                 #if defined(HELTEC_V3_GPS) || defined(HELTEC_V3_TNC) || defined(HELTEC_V3_2_GPS) || defined(HELTEC_V3_2_TNC) || defined(HELTEC_WIRELESS_TRACKER) || defined(HELTEC_WSL_V3_GPS_DISPLAY) || defined(ESP32_C3_DIY_LoRa_GPS) || defined(ESP32_C3_DIY_LoRa_GPS_915) || defined(WEMOS_ESP32_Bat_LoRa_GPS)
                     double inputDivider = (1.0 / (390.0 + 100.0)) * 100.0;  // The voltage divider is a 390k + 100k resistor in series, 100k on the low side.
@@ -151,6 +163,10 @@ namespace BATTERY_Utils {
                     }
                 #else
                     obtainBatteryInfo();
+                    if (Config.battery.monitorVoltage && batteryConnected && batteryVoltage.toFloat() < (Config.battery.sleepVoltage - 0.1)) {
+                        displayShow("!BATTERY!", "", "LOW BATTERY VOLTAGE!", 5000);
+                        POWER_Utils::shutdown();
+                    }
                 #endif
                 batteryMeasurmentTime = millis();
             }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -323,6 +323,9 @@ bool Configuration::readFile() {
 }
 
 void Configuration::setDefaultValues() {
+    beacons.clear();
+    loraTypes.clear();
+
     wifiAP.active                   = true;
     wifiAP.password                 = "1234567890";
 
@@ -433,12 +436,16 @@ void Configuration::setDefaultValues() {
 }
 
 Configuration::Configuration() {
+}
+
+bool Configuration::begin() {
     if (!SPIFFS.begin(false)) {
         Serial.println("SPIFFS Mount Failed, formatting...");
 
         if (!SPIFFS.begin(true)) {
             Serial.println("SPIFFS Format Failed");
-            return;
+            setDefaultValues();
+            return false;
         }
     }
     Serial.println("SPIFFS Ready");
@@ -449,7 +456,17 @@ Configuration::Configuration() {
         writeFile();
         delay(500);
         ESP.restart();
+        return true;
     }
 
-    readFile();
+    if (!readFile() || beacons.empty() || loraTypes.empty()) {
+        Serial.println("Config invalid, creating default...");
+        setDefaultValues();
+        writeFile();
+        delay(500);
+        ESP.restart();
+        return false;
+    }
+
+    return true;
 }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -25,6 +25,15 @@
 
 extern logging::Logger logger;
 
+#if defined(TTGO_T_BEAM_1W)
+    const bool  DEFAULT_BATTERY_MONITOR_VOLTAGE = false;
+    const float DEFAULT_BATTERY_SLEEP_VOLTAGE   = 6.4;
+    const float MIN_BATTERY_SLEEP_VOLTAGE       = 6.0;
+#else
+    const bool  DEFAULT_BATTERY_MONITOR_VOLTAGE = false;
+    const float DEFAULT_BATTERY_SLEEP_VOLTAGE   = 2.9;
+#endif
+
 bool Configuration::writeFile() {
 
     Serial.println("Saving config..");
@@ -202,16 +211,29 @@ bool Configuration::readFile() {
             loraTypes.push_back(loraType);
         }
 
+        bool batteryMonitorVoltageMissing = data["battery"]["monitorVoltage"].isNull();
+        bool batterySleepVoltageMissing = data["battery"]["sleepVoltage"].isNull();
+
         if (data["battery"]["sendVoltage"].isNull() ||
             data["battery"]["voltageAsTelemetry"].isNull() ||
             data["battery"]["sendVoltageAlways"].isNull() ||
-            data["battery"]["monitorVoltage"].isNull() ||
-            data["battery"]["sleepVoltage"].isNull()) needsRewrite = true;
+            batteryMonitorVoltageMissing ||
+            batterySleepVoltageMissing) needsRewrite = true;
         battery.sendVoltage             = data["battery"]["sendVoltage"] | false;
         battery.voltageAsTelemetry      = data["battery"]["voltageAsTelemetry"] | false;
         battery.sendVoltageAlways       = data["battery"]["sendVoltageAlways"] | false;
-        battery.monitorVoltage          = data["battery"]["monitorVoltage"] | false;
-        battery.sleepVoltage            = data["battery"]["sleepVoltage"] | 2.9;
+        battery.monitorVoltage          = data["battery"]["monitorVoltage"] | DEFAULT_BATTERY_MONITOR_VOLTAGE;
+        battery.sleepVoltage            = data["battery"]["sleepVoltage"] | DEFAULT_BATTERY_SLEEP_VOLTAGE;
+        #if defined(TTGO_T_BEAM_1W)
+            if (battery.sleepVoltage < MIN_BATTERY_SLEEP_VOLTAGE) {
+                battery.sleepVoltage = DEFAULT_BATTERY_SLEEP_VOLTAGE;
+                needsRewrite = true;
+            }
+            if (battery.monitorVoltage && battery.sleepVoltage > 6.39 && battery.sleepVoltage < 6.41) {
+                battery.monitorVoltage = false;
+                needsRewrite = true;
+            }
+        #endif
 
         if (data["telemetry"]["active"].isNull() ||
             data["telemetry"]["sendTelemetry"].isNull() ||
@@ -366,8 +388,8 @@ void Configuration::setDefaultValues() {
     battery.sendVoltage             = false;
     battery.voltageAsTelemetry      = false;
     battery.sendVoltageAlways       = false;
-    battery.monitorVoltage          = false;
-    battery.sleepVoltage            = 2.9;
+    battery.monitorVoltage          = DEFAULT_BATTERY_MONITOR_VOLTAGE;
+    battery.sleepVoltage            = DEFAULT_BATTERY_SLEEP_VOLTAGE;
 
     telemetry.active                 = false;
     telemetry.sendTelemetry          = false;

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -23,6 +23,7 @@
 #include "configuration.h"
 #include "board_pinout.h"
 #include "lora_utils.h"
+#include "power_utils.h"
 #include "display.h"
 
 extern logging::Logger  logger;
@@ -200,6 +201,7 @@ namespace LoRa_Utils {
         if (Config.notification.buzzerActive && Config.notification.txBeep) NOTIFICATION_Utils::beaconTxBeep();
 
         #if defined(TTGO_T_BEAM_1W)
+            POWER_Utils::forceFanOn();
             digitalWrite(RADIO_RXEN, LOW);
         #endif
         int state = radio.transmit("\x3c\xff\x01" + newPacket);

--- a/src/menu_utils.cpp
+++ b/src/menu_utils.cpp
@@ -825,7 +825,7 @@ namespace MENU_Utils {
 
                 if (batteryConnected) {
                     String batteryVoltage = BATTERY_Utils::getBatteryInfoVoltage();
-                    #if defined(TTGO_T_Beam_V0_7) || defined(TTGO_T_LORA32_V2_1_GPS) || defined(TTGO_T_LORA32_V2_1_GPS_915) || defined(TTGO_T_LORA32_V2_1_TNC) || defined(TTGO_T_LORA32_V2_1_TNC_915) || defined(HELTEC_V3_GPS) || defined(HELTEC_V3_TNC) || defined(HELTEC_V3_2_GPS) || defined(HELTEC_V3_2_TNC) || defined(HELTEC_WIRELESS_TRACKER) || defined(HELTEC_WSL_V3_GPS_DISPLAY) || defined(TTGO_T_DECK_GPS) || defined(TTGO_T_DECK_PLUS) || defined(LIGHTTRACKER_PLUS_1_0) || defined(TTGO_LORA32_T3S3_V1_2_GPS)
+                    #if defined(TTGO_T_Beam_V0_7) || defined(TTGO_T_LORA32_V2_1_GPS) || defined(TTGO_T_LORA32_V2_1_GPS_915) || defined(TTGO_T_LORA32_V2_1_TNC) || defined(TTGO_T_LORA32_V2_1_TNC_915) || defined(HELTEC_V3_GPS) || defined(HELTEC_V3_TNC) || defined(HELTEC_V3_2_GPS) || defined(HELTEC_V3_2_TNC) || defined(HELTEC_WIRELESS_TRACKER) || defined(HELTEC_WSL_V3_GPS_DISPLAY) || defined(TTGO_T_DECK_GPS) || defined(TTGO_T_DECK_PLUS) || defined(LIGHTTRACKER_PLUS_1_0) || defined(TTGO_LORA32_T3S3_V1_2_GPS) || defined(TTGO_T_BEAM_1W)
                         sixthRowMainMenu = "Battery: ";
                         sixthRowMainMenu += batteryVoltage;
                         sixthRowMainMenu += "V   ";

--- a/src/power_utils.cpp
+++ b/src/power_utils.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <SPI.h>
+#include <math.h>
 #include "notification_utils.h"
 #include "configuration.h"
 #include "battery_utils.h"
@@ -60,8 +61,116 @@ bool    disableGPS;
 
 String  batteryChargeDischargeCurrent    = "";
 
+#if defined(TTGO_T_BEAM_1W)
+    const uint32_t FAN_CHECK_INTERVAL_MS          = 3000;
+    const uint32_t FAN_STARTUP_HOLD_MS            = 10000;
+    const uint32_t FAN_DEFAULT_TX_HOLD_MS         = 60000;
+    const int      FAN_TEMP_AVERAGE_READINGS      = 8;
+    const int      FAN_ADC_MIN_VALID              = 10;
+    const int      FAN_ADC_MAX_VALID              = 4085;
+    const double   FAN_TEMP_ON_C                  = 45.0;
+    const double   FAN_TEMP_OFF_C                 = 38.0;
+    const double   FAN_NTC_BETA                   = 3950.0;
+    const double   FAN_NTC_NOMINAL_RESISTANCE     = 10000.0;
+    const double   FAN_NTC_SERIES_RESISTANCE      = 10000.0;
+    const double   FAN_NTC_NOMINAL_TEMPERATURE_C  = 25.0;
+
+    bool            fanActive                      = false;
+    uint32_t        fanCheckTime                   = 0;
+    uint32_t        fanHoldUntil                   = 0;
+#endif
+
 
 namespace POWER_Utils {
+
+    #if defined(TTGO_T_BEAM_1W)
+        bool isFanHoldActive() {
+            if (fanHoldUntil == 0) return false;
+            if ((int32_t)(fanHoldUntil - millis()) > 0) return true;
+
+            fanHoldUntil = 0;
+            return false;
+        }
+
+        void setFanState(bool active, const char *reason) {
+            if (fanActive == active) return;
+
+            fanActive = active;
+            digitalWrite(FAN_CTRL_PIN, active ? HIGH : LOW);
+            logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "Fan", "%s (%s)", active ? "ON" : "OFF", reason);
+        }
+
+        int readFanTemperatureAdc() {
+            uint32_t sampleSum = 0;
+
+            analogRead(TEMP_PIN);
+            delay(1);
+
+            for (int i = 0; i < FAN_TEMP_AVERAGE_READINGS; i++) {
+                sampleSum += analogRead(TEMP_PIN);
+                delay(1);
+            }
+
+            return sampleSum / FAN_TEMP_AVERAGE_READINGS;
+        }
+
+        double convertFanTemperature(int adcValue) {
+            if (adcValue <= FAN_ADC_MIN_VALID || adcValue >= FAN_ADC_MAX_VALID) return NAN;
+
+            double resistance = FAN_NTC_SERIES_RESISTANCE * ((4095.0 / adcValue) - 1.0);
+            if (resistance <= 0.0) return NAN;
+
+            double temperature = resistance / FAN_NTC_NOMINAL_RESISTANCE;
+            temperature = log(temperature);
+            temperature /= FAN_NTC_BETA;
+            temperature += 1.0 / (FAN_NTC_NOMINAL_TEMPERATURE_C + 273.15);
+            temperature = 1.0 / temperature;
+
+            return temperature - 273.15;
+        }
+    #endif
+
+    void forceFanOn(uint32_t holdTimeMs) {
+        #if defined(TTGO_T_BEAM_1W)
+            if (holdTimeMs == 0) holdTimeMs = FAN_DEFAULT_TX_HOLD_MS;
+
+            pinMode(FAN_CTRL_PIN, OUTPUT);
+            fanHoldUntil = millis() + holdTimeMs;
+            setFanState(true, "forced cooldown");
+        #else
+            (void)holdTimeMs;
+        #endif
+    }
+
+    void handleFan() {
+        #if defined(TTGO_T_BEAM_1W)
+            if (fanCheckTime != 0 && millis() - fanCheckTime < FAN_CHECK_INTERVAL_MS) return;
+            fanCheckTime = millis();
+
+            if (isFanHoldActive()) {
+                setFanState(true, "cooldown");
+                return;
+            }
+
+            int adcValue = readFanTemperatureAdc();
+            double temperature = convertFanTemperature(adcValue);
+
+            if (isnan(temperature)) {
+                setFanState(true, "temperature read failed");
+                logger.log(logging::LoggerLevel::LOGGER_LEVEL_WARN, "Fan", "Invalid NTC ADC reading: %d", adcValue);
+                return;
+            }
+
+            String temperatureText = String(temperature, 1);
+            logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, "Fan", "NTC %s C, ADC %d", temperatureText.c_str(), adcValue);
+
+            if (!fanActive && temperature >= FAN_TEMP_ON_C) {
+                setFanState(true, "temperature high");
+            } else if (fanActive && temperature <= FAN_TEMP_OFF_C) {
+                setFanState(false, "temperature normal");
+            }
+        #endif
+    }
 
     #ifdef VEXT_CTRL
         void vext_ctrl_ON() {
@@ -414,7 +523,9 @@ namespace POWER_Utils {
 
         #if defined(TTGO_T_BEAM_1W)
             pinMode(FAN_CTRL_PIN, OUTPUT);
-            digitalWrite(FAN_CTRL_PIN, HIGH);
+            pinMode(TEMP_PIN, INPUT);
+            digitalWrite(FAN_CTRL_PIN, LOW);
+            forceFanOn(FAN_STARTUP_HOLD_MS);
         #endif
     }
 

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -60,6 +60,7 @@ extern int                  wxModuleType;
 extern bool                 wxModuleFound;
 extern bool                 gpsIsActive;
 extern bool                 gpsShouldSleep;
+extern bool                 batteryConnected;
 
 
 bool	    sendStandingUpdate      = false;
@@ -206,7 +207,7 @@ namespace STATION_Utils {
         String batteryVoltage = BATTERY_Utils::getBatteryInfoVoltage();
         bool shouldSleepLowVoltage = false;
         #if defined(BATTERY_PIN) || defined(HAS_AXP192) || defined(HAS_AXP2101)
-            if (Config.battery.monitorVoltage && batteryVoltage.toFloat() < Config.battery.sleepVoltage) shouldSleepLowVoltage = true;
+            if (Config.battery.monitorVoltage && batteryConnected && batteryVoltage.toFloat() < Config.battery.sleepVoltage) shouldSleepLowVoltage = true;
         #endif
 
         if (!shouldSleepLowVoltage) {


### PR DESCRIPTION
## Summary

This PR improves support for the LilyGO T-Beam 1W hardware variant and fixes a configuration initialization issue that could affect SPIFFS access during startup.

The changes have been tested against both the T-Beam 1W and T-Beam v1.2 PlatformIO environments.

## Changes

### T-Beam 1W Support Improvements

Added support and refinements for the LilyGO T-Beam 1W board:

* Added fan control support using GPIO41
* Implemented fan startup and transmit cooldown behaviour
* Added temperature-based fan control with hysteresis using the onboard NTC temperature sensor
* Added support for displaying battery percentage when using the 2S (7.4V nominal) battery configuration commonly supplied with the T-Beam 1W
* Corrected battery voltage calculations for the T-Beam 1W ADC configuration
* Retained conservative low-voltage behaviour pending user-specific battery calibration

These changes improve thermal management and provide more accurate battery reporting on the 1W hardware variant.

### SPIFFS Initialization Fix

Resolved an initialization timing issue where configuration-related code could access SPIFFS before the filesystem had been initialized.

Changes include:

* Moved filesystem-dependent configuration initialization out of the configuration constructor
* Added explicit configuration initialization after system startup and Serial initialization
* Prevented global objects from accessing configuration data before initialization is complete
* Improved default configuration regeneration by clearing and rebuilding configuration vectors during regeneration

This avoids startup issues caused by attempting to access SPIFFS before `SPIFFS.begin()` has completed.

## Validation

Successfully built and tested using:

```bash
pio run -e ttgo-t-beam-1W
pio run -e ttgo-t-beam-v1_2
```

## Notes

The goal of these changes is to improve stability and usability on the T-Beam 1W while maintaining compatibility with existing supported hardware.
